### PR TITLE
fix active sessions panel in sample dashboard:

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The containers will take a short time to start.  The first time, the Oracle cont
 Once the containers are all running, you can access the services using these URLs:
 
 - [Exporter](http://localhost:9161/metrics)
-- [Prometheus](http://localhost:9000) - try a query for "oracle".
+- [Prometheus](http://localhost:9090) - try a query for "oracle".
 - [Grafana](http://localhost:3000) - username is "admin" and password is "grafana".  An Oracle Database dashboard is provisioned and configured to use data from the exporter.
 
 ### Kubernetes

--- a/docker-compose/grafana/dashboards/3333_rev1.json
+++ b/docker-compose/grafana/dashboards/3333_rev1.json
@@ -212,11 +212,11 @@
               "calculatedInterval": "10m",
               "datasourceErrors": {},
               "errors": {},
-              "expr": "oracledb_sessions_active{instance=\"$host\"}",
+              "expr": "oracledb_sessions_value{instance=\"$host\", status=\"ACTIVE\"}",
               "format": "time_series",
               "interval": "$interval",
               "intervalFactor": 1,
-              "legendFormat": "",
+              "legendFormat": "{{type}}",
               "metric": "",
               "refId": "A",
               "step": 60
@@ -225,7 +225,7 @@
           "thresholds": "",
           "title": "active sessions",
           "transparent": false,
-          "type": "singlestat",
+          "type": "stat",
           "valueFontSize": "100%",
           "valueMaps": [],
           "valueName": "current"


### PR DESCRIPTION
Fixes the active sessions panel in the sample dashboard. Previously, it would display "no data".
Reported by @r-deguchi 

![image](https://github.com/oracle/oracle-db-appdev-monitoring/assets/6345393/c66f9749-08a8-4adf-9248-c52a484a8048)
