### PR TITLE
Use gv$ views over v$ views

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ Currently, we plan to address the following key features:
 The following metrics are exposed by default:
 
 ```text
-# HELP oracledb_activity_execute_count Generic counter metric from v$sysstat view in Oracle.
+# HELP oracledb_activity_execute_count Generic counter metric from gv$sysstat view in Oracle.
 # TYPE oracledb_activity_execute_count gauge
 oracledb_activity_execute_count 64469
-# HELP oracledb_activity_parse_count_total Generic counter metric from v$sysstat view in Oracle.
+# HELP oracledb_activity_parse_count_total Generic counter metric from gv$sysstat view in Oracle.
 # TYPE oracledb_activity_parse_count_total gauge
 oracledb_activity_parse_count_total 25883
-# HELP oracledb_activity_user_commits Generic counter metric from v$sysstat view in Oracle.
+# HELP oracledb_activity_user_commits Generic counter metric from gv$sysstat view in Oracle.
 # TYPE oracledb_activity_user_commits gauge
 oracledb_activity_user_commits 158
-# HELP oracledb_activity_user_rollbacks Generic counter metric from v$sysstat view in Oracle.
+# HELP oracledb_activity_user_rollbacks Generic counter metric from gv$sysstat view in Oracle.
 # TYPE oracledb_activity_user_rollbacks gauge
 oracledb_activity_user_rollbacks 2
 # HELP oracledb_db_platform_value Database platform
@@ -104,7 +104,7 @@ oracledb_exporter_scrapes_total 3
 # HELP oracledb_process_count Gauge metric with count of processes.
 # TYPE oracledb_process_count gauge
 oracledb_process_count 79
-# HELP oracledb_resource_current_utilization Generic counter metric from v$resource_limit view in Oracle (current value).
+# HELP oracledb_resource_current_utilization Generic counter metric from gv$resource_limit view in Oracle (current value).
 # TYPE oracledb_resource_current_utilization gauge
 oracledb_resource_current_utilization{resource_name="branches"} 0
 oracledb_resource_current_utilization{resource_name="cmtcallbk"} 0
@@ -133,7 +133,7 @@ oracledb_resource_current_utilization{resource_name="smartio_sessions"} 0
 oracledb_resource_current_utilization{resource_name="sort_segment_locks"} 2
 oracledb_resource_current_utilization{resource_name="temporary_table_locks"} 0
 oracledb_resource_current_utilization{resource_name="transactions"} 0
-# HELP oracledb_resource_limit_value Generic counter metric from v$resource_limit view in Oracle (UNLIMITED: -1).
+# HELP oracledb_resource_limit_value Generic counter metric from gv$resource_limit view in Oracle (UNLIMITED: -1).
 # TYPE oracledb_resource_limit_value gauge
 oracledb_resource_limit_value{resource_name="branches"} -1
 oracledb_resource_limit_value{resource_name="cmtcallbk"} -1
@@ -262,18 +262,18 @@ For the built-in default metrics, the database user that the exporter uses to co
 
 - dba_tablespace_usage_metrics
 - dba_tablespaces
-- v$system_wait_class
-- v$asm_diskgroup_stat
-- v$datafile
-- v$sysstat
-- v$process
-- v$waitclassmetric
-- v$session
-- v$resource_limit
-- v$parameter
-- v$database
-- v$sqlstats
-- v$sysmetric
+- gv$system_wait_class
+- gv$asm_diskgroup_stat
+- gv$datafile
+- gv$sysstat
+- gv$process
+- gv$waitclassmetric
+- gv$session
+- gv$resource_limit
+- gv$parameter
+- gv$database
+- gv$sqlstats
+- gv$sysmetric
 - v$diag_alert_ext (for alert logs only)
 
 ## Alert logs
@@ -794,7 +794,7 @@ context = "db_platform"
 labels = [ "platform_name" ]
 metricsdesc = { value = "Database platform" }
 request = '''
-SELECT platform_name, 1 as value FROM v$database
+SELECT platform_name, 1 as value FROM gv$database
 '''
 databases = [ "db2", "db3" ]
 ```

--- a/collector/default_metrics.toml
+++ b/collector/default_metrics.toml
@@ -2,15 +2,19 @@
 context = "sessions"
 labels = [ "status", "type" ]
 metricsdesc = { value= "Gauge metric with count of sessions by status and type." }
-request = "SELECT status, type, COUNT(*) as value FROM v$session GROUP BY status, type"
+request = '''
+select status, type, count(*) as value
+from gv$session
+group by status, type
+'''
 
 [[metric]]
 context = "resource"
 labels = [ "resource_name" ]
-metricsdesc = { current_utilization= "Generic counter metric from v$resource_limit view in Oracle (current value).", limit_value="Generic counter metric from v$resource_limit view in Oracle (UNLIMITED: -1)." }
+metricsdesc = { current_utilization= "Generic counter metric from gv$resource_limit view in Oracle (current value).", limit_value="Generic counter metric from v$resource_limit view in Oracle (UNLIMITED: -1)." }
 request = '''
-SELECT resource_name, current_utilization, CASE WHEN TRIM(limit_value) LIKE 'UNLIMITED' THEN '-1' ELSE TRIM(limit_value) END as limit_value
-FROM v$resource_limit
+select resource_name, current_utilization, case when trim(limit_value) like 'unlimited' then '-1' else trim(limit_value) end as limit_value
+from gv$resource_limit
 '''
 ignorezeroresult = true
 
@@ -18,19 +22,28 @@ ignorezeroresult = true
 context = "asm_diskgroup"
 labels = [ "name" ]
 metricsdesc = { total = "Total size of ASM disk group.", free = "Free space available on ASM disk group." }
-request = "SELECT name,total_mb*1024*1024 as total,free_mb*1024*1024 as free FROM v$asm_diskgroup_stat where exists (select 1 from v$datafile where name like '+%')"
+request = '''
+select name, total_mb*1024*1024 as total, free_mb*1024*1024 as free
+from gv$asm_diskgroup_stat
+where exists (select 1 from gv$datafile where name like '+%')
+and inst_id = (select max(inst_id) from gv$instance)
+group by name, total_mb, free_mb
+'''
 ignorezeroresult = true
 
 [[metric]]
 context = "activity"
-metricsdesc = { value="Generic counter metric from v$sysstat view in Oracle." }
+metricsdesc = { value="Generic counter metric from gv$sysstat view in Oracle." }
 fieldtoappend = "name"
-request = "SELECT name, value FROM v$sysstat WHERE name IN ('parse count (total)', 'execute count', 'user commits', 'user rollbacks')"
+request = '''
+select name, value from gv$sysstat
+where name in ('parse count (total)', 'execute count', 'user commits', 'user rollbacks')
+'''
 
 [[metric]]
 context = "process"
 metricsdesc = { count="Gauge metric with count of processes." }
-request = "SELECT COUNT(*) as count FROM v$process"
+request = "select count(*) as count from gv$process"
 
 [[metric]]
 context = "wait_time"
@@ -43,7 +56,7 @@ select
   wait_class,
   round(time_waited/100,3) time_waited_sec_total,
   con_id
-from v$system_wait_class
+from gv$system_wait_class
 where wait_class <> 'Idle'
 '''
 ignorezeroresult = true
@@ -62,7 +75,17 @@ SELECT
     dtum.used_percent
 FROM  dba_tablespace_usage_metrics dtum, dba_tablespaces dt
 WHERE dtum.tablespace_name = dt.tablespace_name
-ORDER by tablespace
+and dt.contents != 'TEMPORARY'
+union
+SELECT
+    dt.tablespace_name as tablespace,
+    'TEMPORARY' as type,
+    dt.tablespace_size - dt.free_space as bytes,
+    dt.tablespace_size as max_bytes,
+    dt.free_space as free,
+    ((dt.tablespace_size - dt.free_space) / dt.tablespace_size)
+FROM  dba_temp_free_space dt
+order by tablespace
 '''
 
 [[metric]]
@@ -71,7 +94,7 @@ labels = [ "name" ]
 metricsdesc = { value = "Database system resources metric" }
 request = '''
 select name, value
-from v$parameter
+from gv$parameter
 where name in ('cpu_count', 'sga_max_size', 'pga_aggregate_limit')
 '''
 
@@ -80,7 +103,7 @@ context = "db_platform"
 labels = [ "platform_name" ]
 metricsdesc = { value = "Database platform" }
 request = '''
-SELECT platform_name, 1 as value FROM v$database
+SELECT platform_name, 1 as value FROM gv$database
 '''
 
 [[metric]]
@@ -89,12 +112,17 @@ labels = [ "sql_id", "sql_text" ]
 metricsdesc = { elapsed = "SQL statement elapsed time running" }
 request = '''
 select * from (
-select sql_id, elapsed_time / 1000000 as elapsed, SUBSTRB(REPLACE(sql_text,'',' '),1,55) as sql_text
-from   V$SQLSTATS
+select sql_id, elapsed_time / 1000000 as elapsed, substrb(replace(sql_text,'',' '),1,55) as sql_text
+from   gv$sqlstats
 order by elapsed_time desc
-) where ROWNUM <= 15
+) where rownum <= 15
 '''
 ignorezeroresult = true
+# scrapeinterval = "5m"
+# The previous line is an example of changing the interval at which this one metric
+# will be scraped. You may wish to do this to scrape a metric less often, if the SQL
+# statement to collect that metric places more load on your database instance than
+# desired when it is run at every scrape.
 
 [[metric]]
 context = "cache_hit_ratio"
@@ -102,7 +130,7 @@ labels = [ "cache_hit_type" ]
 metricsdesc = { value = "Cache Hit Ratio" }
 request = '''
 select metric_name cache_hit_type, value
-from v$sysmetric
+from gv$sysmetric
 where group_id=2 and metric_id in (2000,2050,2112,2110)
 '''
 ignorezeroresult = true

--- a/custom-metrics-example/custom-metrics.toml
+++ b/custom-metrics-example/custom-metrics.toml
@@ -1,12 +1,20 @@
 [[metric]]
 context = "slow_queries"
 metricsdesc = { p95_time_usecs= "Gauge metric with percentile 95 of elapsed time.", p99_time_usecs= "Gauge metric with percentile 99 of elapsed time." }
-request = "select  percentile_disc(0.95)  within group (order by elapsed_time) as p95_time_usecs, percentile_disc(0.99)  within group (order by elapsed_time) as p99_time_usecs from v$sql where last_active_time >= sysdate - 5/(24*60)"
+request = '''
+select percentile_disc(0.95) within group (order by elapsed_time) as p95_time_usecs, percentile_disc(0.99) within group (order by elapsed_time) as p99_time_usecs
+from gv$sql
+where last_active_time >= sysdate - 5/(24*60)
+'''
 
 [[metric]]
 context = "big_queries"
 metricsdesc = { p95_rows= "Gauge metric with percentile 95 of returned rows.", p99_rows= "Gauge metric with percentile 99 of returned rows." }
-request = "select  percentile_disc(0.95)  within group (order by rownum) as p95_rows, percentile_disc(0.99)  within group (order by rownum) as p99_rows from v$sql where last_active_time >= sysdate - 5/(24*60)"
+request = '''
+select percentile_disc(0.95) within group (order by rownum) as p95_rows, percentile_disc(0.99) within group (order by rownum) as p99_rows
+from gv$sql
+where last_active_time >= sysdate - 5/(24*60)
+'''
 
 [[metric]]
 context = "size_user_segments_top100"

--- a/custom-metrics-example/txeventq-metrics.toml
+++ b/custom-metrics-example/txeventq-metrics.toml
@@ -13,7 +13,7 @@ WHERE
 [[metric]]
 context = "teq"
 metricsdesc = { curr_inst_id = "ID of current instance" }
-request = "SELECT instance_number AS curr_inst_id FROM v$instance"
+request = "SELECT instance_number AS curr_inst_id FROM gv$instance"
 
 [[metric]]
 context = "teq"

--- a/default-metrics.toml
+++ b/default-metrics.toml
@@ -2,15 +2,19 @@
 context = "sessions"
 labels = [ "status", "type" ]
 metricsdesc = { value= "Gauge metric with count of sessions by status and type." }
-request = "SELECT status, type, COUNT(*) as value FROM v$session GROUP BY status, type"
+request = '''
+select status, type, count(*) as value
+from gv$session
+group by status, type
+'''
 
 [[metric]]
 context = "resource"
 labels = [ "resource_name" ]
 metricsdesc = { current_utilization= "Generic counter metric from v$resource_limit view in Oracle (current value).", limit_value="Generic counter metric from v$resource_limit view in Oracle (UNLIMITED: -1)." }
 request = '''
-SELECT resource_name, current_utilization, CASE WHEN TRIM(limit_value) LIKE 'UNLIMITED' THEN '-1' ELSE TRIM(limit_value) END as limit_value 
-FROM v$resource_limit
+select resource_name, current_utilization, case when trim(limit_value) like 'unlimited' then '-1' else trim(limit_value) end as limit_value
+from gv$resource_limit
 '''
 ignorezeroresult = true
 
@@ -18,19 +22,28 @@ ignorezeroresult = true
 context = "asm_diskgroup"
 labels = [ "name" ]
 metricsdesc = { total = "Total size of ASM disk group.", free = "Free space available on ASM disk group." }
-request = "SELECT name,total_mb*1024*1024 as total,free_mb*1024*1024 as free FROM v$asm_diskgroup_stat where exists (select 1 from v$datafile where name like '+%')"
+request = '''
+select name, total_mb*1024*1024 as total, free_mb*1024*1024 as free
+from gv$asm_diskgroup_stat
+where exists (select 1 from gv$datafile where name like '+%')
+and inst_id = (select max(inst_id) from gv$instance)
+group by name, total_mb, free_mb
+'''
 ignorezeroresult = true
 
 [[metric]]
 context = "activity"
-metricsdesc = { value="Generic counter metric from v$sysstat view in Oracle." }
+metricsdesc = { value="Generic counter metric from gv$sysstat view in Oracle." }
 fieldtoappend = "name"
-request = "SELECT name, value FROM v$sysstat WHERE name IN ('parse count (total)', 'execute count', 'user commits', 'user rollbacks')"
+request = '''
+select name, value from gv$sysstat
+where name in ('parse count (total)', 'execute count', 'user commits', 'user rollbacks')
+'''
 
 [[metric]]
 context = "process"
 metricsdesc = { count="Gauge metric with count of processes." }
-request = "SELECT COUNT(*) as count FROM v$process"
+request = "select count(*) as count from gv$process"
 
 [[metric]]
 context = "wait_time"
@@ -43,7 +56,7 @@ select
   wait_class,
   round(time_waited/100,3) time_waited_sec_total,
   con_id
-from v$system_wait_class
+from gv$system_wait_class
 where wait_class <> 'Idle'
 '''
 ignorezeroresult = true
@@ -80,8 +93,8 @@ context = "db_system"
 labels = [ "name" ]
 metricsdesc = { value = "Database system resources metric" }
 request = '''
-select name, value 
-from v$parameter 
+select name, value
+from gv$parameter
 where name in ('cpu_count', 'sga_max_size', 'pga_aggregate_limit')
 '''
 
@@ -90,7 +103,7 @@ context = "db_platform"
 labels = [ "platform_name" ]
 metricsdesc = { value = "Database platform" }
 request = '''
-SELECT platform_name, 1 as value FROM v$database
+SELECT platform_name, 1 as value FROM gv$database
 '''
 
 [[metric]]
@@ -99,16 +112,16 @@ labels = [ "sql_id", "sql_text" ]
 metricsdesc = { elapsed = "SQL statement elapsed time running" }
 request = '''
 select * from (
-select sql_id, elapsed_time / 1000000 as elapsed, SUBSTRB(REPLACE(sql_text,'',' '),1,55) as sql_text
-from   V$SQLSTATS
+select sql_id, elapsed_time / 1000000 as elapsed, substrb(replace(sql_text,'',' '),1,55) as sql_text
+from   gv$sqlstats
 order by elapsed_time desc
-) where ROWNUM <= 15
+) where rownum <= 15
 '''
 ignorezeroresult = true
 # scrapeinterval = "5m"
 # The previous line is an example of changing the interval at which this one metric
 # will be scraped. You may wish to do this to scrape a metric less often, if the SQL
-# statement to collect that metric places more load on your database instance than 
+# statement to collect that metric places more load on your database instance than
 # desired when it is run at every scrape.
 
 [[metric]]
@@ -117,7 +130,7 @@ labels = [ "cache_hit_type" ]
 metricsdesc = { value = "Cache Hit Ratio" }
 request = '''
 select metric_name cache_hit_type, value
-from v$sysmetric
+from gv$sysmetric
 where group_id=2 and metric_id in (2000,2050,2112,2110)
 '''
 ignorezeroresult = true

--- a/docker-compose/exporter/txeventq-metrics.toml
+++ b/docker-compose/exporter/txeventq-metrics.toml
@@ -16,7 +16,7 @@ scrapeinterval = "30s"
 [[metric]]
 context = "teq"
 metricsdesc = { curr_inst_id = "ID of current instance" }
-request = "SELECT instance_number AS curr_inst_id FROM v$instance"
+request = "SELECT instance_number AS curr_inst_id FROM gv$instance"
 ignorezeroresult = true
 
 [[metric]]


### PR DESCRIPTION
This mainly applies to the default metrics, and makes them applicable to multi-instance databases