### PR TITLE
Enhance database connection handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,11 @@ func main() {
 			logger.Info(dbname + " database max idle connections is 0, so will use Oracle connection pool. Tune with database pooling settings")
 		}
 	}
-	exporter := collector.NewExporter(logger, m)
+	exporter, err := collector.NewExporter(logger, m)
+	if err != nil {
+		logger.Error("unable to create exporter", "error", err)
+		return
+	}
 	if exporter.ScrapeInterval() != 0 {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
Proposed fix for issue: #252 

1. If a database connection fails, it will log the error and skip that database.
2. If at least one database connects successfully, the exporter will start and expose metrics for the connected databases.
3. If *no* databases connect successfully, the exporter will exit.
