### PR TITLE
Warmup the connection pool per database

### DIFF
--- a/collector/database.go
+++ b/collector/database.go
@@ -74,6 +74,9 @@ func NewDatabase(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) *D
 	}
 }
 
+// WarmupConnectionPool serially acquires connections to "warm up" the connection pool.
+// This is a workaround for a perceived bug in ODPI_C where rapid acquisition of connections
+// results in a SIGABRT.
 func (d *Database) WarmupConnectionPool(logger *slog.Logger) {
 	var connections []*sql.Conn
 	poolSize := d.Config.GetMaxOpenConns()

--- a/collector/database.go
+++ b/collector/database.go
@@ -4,6 +4,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"github.com/godror/godror"
@@ -64,13 +65,45 @@ func (d *Database) constLabels() map[string]string {
 
 func NewDatabase(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) *Database {
 	db, dbtype := connect(logger, dbname, dbconfig)
-
 	return &Database{
 		Name:    dbname,
 		Up:      0,
 		Session: db,
 		Type:    dbtype,
 		Config:  dbconfig,
+	}
+}
+
+func (d *Database) WarmupConnectionPool(logger *slog.Logger) {
+	var connections []*sql.Conn
+	poolSize := d.Config.GetMaxOpenConns()
+	if poolSize < 1 {
+		poolSize = d.Config.GetPoolMaxConnections()
+	}
+	if poolSize > 100 { // defensively cap poolsize
+		poolSize = 100
+	}
+	warmup := func(i int) {
+		time.Sleep(100 * time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		conn, err := d.Session.Conn(ctx)
+		if err != nil {
+			logger.Debug("Failed to open database connection on warmup", "conn", i, "error", err, "database", d.Name)
+			return
+		}
+		connections = append(connections, conn)
+	}
+	for i := 0; i < poolSize; i++ {
+		warmup(i + 1)
+	}
+
+	logger.Debug("Warmed connection pool", "total", len(connections), "database", d.Name)
+	for i, conn := range connections {
+		if err := conn.Close(); err != nil {
+			logger.Debug("Failed to return database connection to pool on warmup", "conn", i+1, "error", err, "database", d.Name)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -110,14 +110,7 @@ func main() {
 		logger.Error("unable to load metrics configuration", "error", err)
 		return
 	}
-
-	for dbname, db := range m.Databases {
-		if db.GetMaxOpenConns() > 0 {
-			logger.Info(dbname + " database max idle connections is greater than 0, so will use go-sql connection pool and pooling settings will be ignored")
-		} else {
-			logger.Info(dbname + " database max idle connections is 0, so will use Oracle connection pool. Tune with database pooling settings")
-		}
-	}
+	
 	exporter := collector.NewExporter(logger, m)
 	if exporter.ScrapeInterval() != 0 {
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Trying something for #258 - I noticed the ODPI CGO layer may crash if you rapidly acquire connections. The goal here is to "slowly" warm the connection pool for each database. In practice, I didn't see any more crashes (ran this hundreds of times with a few databases).

It's not very neat, and would be nice if we didn't have to do this. I had to put a time.sleep in the warmup code, since even serially acquiring connections required some backoff in a single goroutine.