### PR TITLE
Add query timeouts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 Our current priorities are support for Exadata metrics.  We expect to address these in an upcoming release.
 
 - Fixed a case-sensitive issue with resource name in the default metrics file.
+- Add query timeouts to initial database connections, which could cause the exporter to hang in multi-database configurations
+- Fix an issue where rapidly acquiring connections could cause the exporter to crash. This was more common in multi-database configurations, due to the increased number of connection pools. 
 
 ### Version 2.0.1, June 12, 2025
 


### PR DESCRIPTION
On testing, found the exporter would hang when initially connecting to databases that are down or have invalid configurations. A query timeout is added so no one database will block the exporter from scraping other databases. Fixes #252