### PR TITLE
Add arbitrary labels on a per-database basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,10 +723,8 @@ databases:
 
     ## Arbitrary labels to add to each metric scraped from this database
     # labels:
-    #   - name: label_name
-    #     value: label_value
-    #   - name: label_name2
-    #     value: label_value2
+    #   label_name1: label_value1
+    #   label_name2: label_value2
 
 
 metrics:
@@ -806,10 +804,8 @@ databases:
     ## full labelset. If the label isn't set for a particular database, then it
     ## will just be set to an empty string.
     # labels:
-    #   - name: label_name
-    #     value: label_value
-    #   - name: label_name2
-    #     value: label_value2
+    #   label_name1: label_value1
+    #   label_name2: label_value2
 
   db2:
     ## Database username
@@ -854,10 +850,8 @@ databases:
     ## full labelset. If the label isn't set for a particular database, then it
     ## will just be set to an empty string.
     # labels:
-    #   - name: label_name
-    #     value: label_value
-    #   - name: label_name2
-    #     value: label_value2
+    #   label_name1: label_value1
+    #   label_name2: label_value2
 
 metrics:
   ## How often to scrape metrics. If not provided, metrics will be scraped on request.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -53,21 +53,21 @@ func NewExporter(logger *slog.Logger, m *MetricsConfiguration) *Exporter {
 	wg := &sync.WaitGroup{}
 
 	var allConstLabels []string
-	// All the metrics of the same name need to have the same labels
+	// All the metrics of the same name need to have the same set of labels
 	// If a label is set for a particular database, it must be included also
 	// in the same metrics collected from other databases. It will just be
 	// set to a blank value.
 	for _, dbconfig := range m.Databases {
-		for _, label := range dbconfig.Labels {
-			if (!slices.Contains(allConstLabels, label.Name)) {
-				allConstLabels = append(allConstLabels, label.Name)
+		for label, _ := range dbconfig.Labels {
+			if (!slices.Contains(allConstLabels, label)) {
+				allConstLabels = append(allConstLabels, label)
 			}
 		}
 	}
 
 	for dbname, dbconfig := range m.Databases {
 		logger.Info("Initializing database", "database", dbname)
-		database := NewDatabase(logger, dbname, dbconfig, allConstLabels)
+		database := NewDatabase(logger, dbname, dbconfig)
 		databases = append(databases, database)
 		wg.Add(1)
 		go func() {
@@ -106,10 +106,23 @@ func NewExporter(logger *slog.Logger, m *MetricsConfiguration) *Exporter {
 		MetricsConfiguration: m,
 		databases:            databases,
 		lastScraped:          map[string]*time.Time{},
+		allConstLabels:       allConstLabels,
 	}
 	e.metricsToScrape = e.DefaultMetrics()
 
 	return e
+}
+
+func (e *Exporter) constLabels() map[string]string {
+	// All the metrics of the same name need to have the same labels
+	// If a label is set for a particular database, it must be included also
+	// in the same metrics collected from other databases. It will just be
+	// set to a blank value.
+	labels := map[string]string{}
+	for _, label := range e.allConstLabels {
+		labels[label] = ""
+	}
+	return labels
 }
 
 // Describe describes all the metrics exported by the Oracle DB exporter.
@@ -163,8 +176,8 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- e.error
 	e.scrapeErrors.Collect(ch)
 	for _, db := range e.databases {
-		ch <- db.DBTypeMetric()
-		ch <- db.UpMetric()
+		ch <- db.DBTypeMetric(e.constLabels())
+		ch <- db.UpMetric(e.constLabels())
 	}
 }
 
@@ -218,7 +231,7 @@ func (e *Exporter) scheduledScrape(tick *time.Time) {
 	metricCh <- e.error
 	e.scrapeErrors.Collect(metricCh)
 	for _, db := range e.databases {
-		metricCh <- db.UpMetric()
+		metricCh <- db.UpMetric(e.constLabels())
 	}
 	close(metricCh)
 	wg.Wait()
@@ -414,7 +427,7 @@ func (e *Exporter) scrapeGenericValues(d *Database, ch chan<- prometheus.Metric,
 	metricsDesc map[string]string, metricsType map[string]string, metricsBuckets map[string]map[string]string,
 	fieldToAppend string, ignoreZeroResult bool, request string, queryTimeout time.Duration) error {
 	metricsCount := 0
-	constLabels := d.constLabels()
+	constLabels := d.constLabels(e.constLabels())
 	e.logger.Debug("labels", constLabels)
 	genericParser := func(row map[string]string) error {
 		// Construct labels value

--- a/collector/config.go
+++ b/collector/config.go
@@ -27,7 +27,7 @@ type DatabaseConfig struct {
 	URL           string `yaml:"url"`
 	ConnectConfig `yaml:",inline"`
 	Vault         *VaultConfig `yaml:"vault,omitempty"`
-	Labels        []DatabaseLabel `yaml:"labels,omitempty"`
+	Labels        map[string]string `yaml:"labels,omitempty"`
 }
 
 type ConnectConfig struct {
@@ -71,11 +71,6 @@ type LoggingConfig struct {
 	LogDisable     *int           `yaml:"disable"`
 	LogInterval    *time.Duration `yaml:"interval"`
 	LogDestination string         `yaml:"destination"`
-}
-
-type DatabaseLabel struct {
-	Name string `yaml:"name"`
-	Value string `yaml:"value"`
 }
 
 func (m *MetricsConfiguration) LogDestination() string {

--- a/collector/types.go
+++ b/collector/types.go
@@ -24,6 +24,7 @@ type Exporter struct {
 	databases       []*Database
 	logger          *slog.Logger
 	lastScraped     map[string]*time.Time
+	allConstLabels  []string
 }
 
 type Database struct {
@@ -32,7 +33,6 @@ type Database struct {
 	Session         *sql.DB
 	Type            float64
 	Config          DatabaseConfig
-	allConstLabels  []string
 }
 
 type Config struct {

--- a/example-config-multi-database.yaml
+++ b/example-config-multi-database.yaml
@@ -45,6 +45,12 @@ databases:
     # poolMaxConnections: 15
     ## Oracle Database Connection pool minimum size
     # poolMinConnections: 15
+
+    ## Arbitrary labels to add to each metric scraped from this database
+    # labels:
+    #   label_name1: label_value1
+    #   label_name2: label_value2
+
   db2:
     ## Database username
     username: ${DB2_USERNAME}
@@ -81,6 +87,11 @@ databases:
     # poolMaxConnections: 15
     ## Oracle Database Connection pool minimum size
     # poolMinConnections: 15
+
+    ## Arbitrary labels to add to each metric scraped from this database
+    # labels:
+    #   label_name1: label_value1
+    #   label_name2: label_value2
 
 metrics:
   ## How often to scrape metrics. If not provided, metrics will be scraped on request.


### PR DESCRIPTION
This accomplishes the feature request that I entered at https://github.com/oracle/oracle-db-appdev-monitoring/issues/275

Arbitrary per-database labels can be added to the database stanzas in the configuration, like:
```
    # labels:
    #   - name: label_name
    #     value: label_value
    #   - name: label_name2
    #     value: label_value2
```

