### PR TITLE
Vault Issue caused by passing nil check

### DIFF
--- a/collector/config.go
+++ b/collector/config.go
@@ -152,7 +152,7 @@ func (d DatabaseConfig) GetPassword() string {
 	if d.Vault == nil {
 		return d.Password
 	}
-	if d.Vault.OCI.UsernameSecret != "" {
+	if d.Vault.OCI.PasswordSecret != "" {
 		return ocivault.GetVaultSecret(d.Vault.OCI.ID, d.Vault.OCI.PasswordSecret)
 	}
 	if d.Vault.Azure != nil {

--- a/collector/config.go
+++ b/collector/config.go
@@ -136,29 +136,25 @@ func (c ConnectConfig) GetQueryTimeout() int {
 }
 
 func (d DatabaseConfig) GetUsername() string {
-	if d.Vault == nil {
-		return d.Username
-	}
+
 	if d.Vault.OCI.UsernameSecret != "" {
 		return ocivault.GetVaultSecret(d.Vault.OCI.ID, d.Vault.OCI.UsernameSecret)
 	}
-	if d.Vault.Azure != nil {
+	if d.Vault.Azure.UsernameSecret != "" {
 		return azvault.GetVaultSecret(d.Vault.Azure.ID, d.Vault.Azure.UsernameSecret)
 	}
-	return ""
+	return d.Username
 }
 
 func (d DatabaseConfig) GetPassword() string {
-	if d.Vault == nil {
-		return d.Password
-	}
+
 	if d.Vault.OCI.PasswordSecret != "" {
 		return ocivault.GetVaultSecret(d.Vault.OCI.ID, d.Vault.OCI.PasswordSecret)
 	}
-	if d.Vault.Azure != nil {
+	if d.Vault.Azure.PasswordSecret != "" {
 		return azvault.GetVaultSecret(d.Vault.Azure.ID, d.Vault.Azure.PasswordSecret)
 	}
-	return ""
+	return d.Password
 }
 
 func LoadMetricsConfiguration(logger *slog.Logger, cfg *Config, path string) (*MetricsConfiguration, error) {

--- a/collector/config.go
+++ b/collector/config.go
@@ -26,7 +26,7 @@ type DatabaseConfig struct {
 	Password      string
 	URL           string `yaml:"url"`
 	ConnectConfig `yaml:",inline"`
-	Vault         *VaultConfig `yaml:"vault,omitempty"`
+	Vault         *VaultConfig      `yaml:"vault,omitempty"`
 	Labels        map[string]string `yaml:"labels,omitempty"`
 }
 
@@ -139,7 +139,7 @@ func (d DatabaseConfig) GetUsername() string {
 	if d.Vault == nil {
 		return d.Username
 	}
-	if d.Vault.OCI != nil {
+	if d.Vault.OCI.UsernameSecret != "" {
 		return ocivault.GetVaultSecret(d.Vault.OCI.ID, d.Vault.OCI.UsernameSecret)
 	}
 	if d.Vault.Azure != nil {
@@ -152,7 +152,7 @@ func (d DatabaseConfig) GetPassword() string {
 	if d.Vault == nil {
 		return d.Password
 	}
-	if d.Vault.OCI != nil {
+	if d.Vault.OCI.UsernameSecret != "" {
 		return ocivault.GetVaultSecret(d.Vault.OCI.ID, d.Vault.OCI.PasswordSecret)
 	}
 	if d.Vault.Azure != nil {


### PR DESCRIPTION
- Added a minor patch correcting the if-check for retrieving the username and password

```bash
time=2025-08-06T17:23:07.779Z level=INFO source=main.go:75 msg="FREE_INTERVAL end var is not present, will not periodically attempt to release memory"
time=2025-08-06T17:23:07.779Z level=INFO source=main.go:82 msg="RESTART_INTERVAL env var is not present, so will not restart myself periodically"
time=2025-08-06T17:23:07.779Z level=WARN source=config.go:175 msg="Configuring default database from CLI parameters is deprecated. Use of the '--config.file' argument is preferred. See https://github.com/oracle/oracle-db-appdev-monitoring?tab=readme-ov-file#standalone-binary"
time=2025-08-06T17:23:07.779Z level=INFO source=collector.go:54 msg="Initializing database" database=default
2025/08/06 17:23:12 Error returned by Secrets Service. Http Status Code: 400. Error Code: InvalidParameter. Opc request id: 2d9890aa915e8e2db177b62feb747771/6BAFA3D27E147ACC438756428D483DB5/5B97EA4B1A433CEEE2B6E7BCD3964F20. Message: query param secretName size must be between 1 and 255
Operation Name: GetSecretBundleByName
Timestamp: 2025-08-06 17:23:13 +0000 GMT
Client Version: Oracle-GoSDK/65.93.2
Request Endpoint: POST https://secrets.vaults.us-phoenix-1.oci.oraclecloud.com/20190301/secretbundles/actions/getByName?secretName=&vaultId=ocid1.vault.oc1.phx.eftfoyniaaahc.abyhqljstqhm23hznw7uanvqdcxrs4k34fspg5jg7cw3zylez5t5uzizb3fq
Troubleshooting Tips: See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_400__400_invalidparameter for more information about resolving this error.
Also see https://docs.oracle.com/iaas/api/#/en/secretretrieval/20190301/SecretBundle/GetSecretBundleByName for details on this operation's requirements.
To get more info on the failing request, you can set OCI_GO_SDK_DEBUG env var to info or higher level to log the request/response details.
If you are unable to resolve this Secrets issue, please contact Oracle support and provide them this full error message.
```

### Expected Behavior
Only the password secret is provided, retrieve only the password.

### Actual Behavior
Both username and password are being retrieved, when only the password details is provided.
The second check without the necessary secretName causes the error in the Vault Request.

### The Issue
The check [here](https://github.com/oracle/oracle-db-appdev-monitoring/blob/71d4800f57238eab9b67c6775afa89928d71ae16/collector/config.go#L138) will cause an issue, if `OCIConfig` is defined, even with just the VaultID and now username or password secrets -- causing the nil check [here](https://github.com/oracle/oracle-db-appdev-monitoring/blob/71d4800f57238eab9b67c6775afa89928d71ae16/collector/config.go#L138) to pass and therefore request the username and password from the vault.
