### PR TITLE
Adding Username support for non-Config File approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,10 +977,11 @@ databases:
 
 #### OCI Vault CLI Configuration
 
-If using the default database with CLI parameters, the exporter will read the password from a secret stored in OCI Vault if you set these two environment variables:
+If using the default database with CLI parameters, the exporter will read the username and password from a secret stored in OCI Vault if you set these two environment variables:
 
 - `OCI_VAULT_ID` should be set to the OCID of the OCI vault that you wish to use
-- `OCI_VAULT_SECRET_NAME` should be set to the name of the secret in the OCI vault which contains the database password
+- `OCI_VAULT_USERNAME_SECRET` should be set to the name of the secret in the OCI vault which contains the database username
+- `OCI_VAULT_PASSWORD_SECRET` should be set to the name of the secret in the OCI vault which contains the database password
 
 > Note that the process must be running under a user that has the OCI CLI installed and configured correctly to access the desired tenancy and region. The OCI Profile used is `DEFAULT`.
 

--- a/collector/config.go
+++ b/collector/config.go
@@ -234,10 +234,9 @@ func (m *MetricsConfiguration) defaultDatabase(cfg *Config) DatabaseConfig {
 	if ociVaultID, useOciVault := os.LookupEnv("OCI_VAULT_ID"); useOciVault {
 		dbconfig.Vault = &VaultConfig{
 			OCI: &OCIVault{
-				ID: ociVaultID,
-				// For the CLI, only the password may be loaded from a secret. If you need to load
-				// both the username and password from OCI Vault, use the exporter configuration file.
-				PasswordSecret: os.Getenv("OCI_VAULT_SECRET_NAME"),
+				ID:             ociVaultID,
+				UsernameSecret: os.Getenv("OCI_VAULT_USERNAME_SECRET"),
+				PasswordSecret: os.Getenv("OCI_VAULT_PASSWORD_SECRET"),
 			},
 		}
 	} else if azVaultID, useAzVault := os.LookupEnv("AZ_VAULT_ID"); useAzVault {


### PR DESCRIPTION
Enhancement PR:
- Adding support for username retrieval from OCI Vault using command line approach
Though it may no longer be necessary with the config-file approach.

Justification:
- Match azure implementation
- If a simpler deployment using CLI is desired
- If deploying with the DB Operator, without use of config file