### PR TITLE
WARN duplicated database connections

### DIFF
--- a/collector/config.go
+++ b/collector/config.go
@@ -310,15 +310,23 @@ func (m *MetricsConfiguration) validate(logger *slog.Logger) error {
 
 // checkDuplicatedDatabases validates duplicated databases. If a database entry is duplicated, log a warning.
 func (m *MetricsConfiguration) checkDuplicatedDatabases(logger *slog.Logger) {
-	dbs := map[string][]string{}
+	type dbkey struct {
+		URL      string
+		Username string
+	}
+
+	dbs := map[dbkey][]string{}
 	for db, cfg := range m.Databases {
-		key := strings.ToLower(cfg.URL + cfg.Username)
+		key := dbkey{
+			URL:      cfg.URL,
+			Username: strings.ToLower(cfg.Username),
+		}
 		dbs[key] = append(dbs[key], db)
 	}
 
 	for _, v := range dbs {
 		if len(v) > 1 {
-			logger.Warn("duplicated database connections", "database connections", strings.Join(v, ", "))
+			logger.Warn("duplicated database connections", "database connections", strings.Join(v, ", "), "count", len(v))
 		}
 	}
 }


### PR DESCRIPTION
Example log message: msg="duplicated database connections" "database connections"="db1, local"

the MetricsConfiguration.validate() function is created to handle future configuration validations. Currently it will only log a WARN message if a database configuration is duplicated.

Fixes #321 