### PR TITLE
Invalidate database on failed login

### DIFF
--- a/alertlog/alertlog.go
+++ b/alertlog/alertlog.go
@@ -24,6 +24,10 @@ type LogRecord struct {
 var databaseFailures map[string]int = map[string]int{}
 
 func UpdateLog(logDestination string, logger *slog.Logger, d *collector.Database) {
+	// Do not try to query the alert log if the database configuration is invalid.
+	if !d.IsValid() {
+		return
+	}
 
 	queryFailures := databaseFailures[d.Name]
 	if queryFailures == 3 {

--- a/collector/database.go
+++ b/collector/database.go
@@ -16,6 +16,10 @@ import (
 	"time"
 )
 
+const (
+	ora01017code = 1017
+)
+
 func (d *Database) UpMetric(exporterLabels map[string]string) prometheus.Metric {
 	desc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "up"),
@@ -150,7 +154,7 @@ func isInvalidCredentialsError(err error) bool {
 	if !ok {
 		return false
 	}
-	return oraErr.Code() == 1017
+	return oraErr.Code() == ora01017
 }
 
 func connect(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) (*sql.DB, float64) {

--- a/collector/types.go
+++ b/collector/types.go
@@ -34,6 +34,8 @@ type Database struct {
 	// MetricsCache holds computed metrics for a database, so these metrics are available on each scrape.
 	// Given a metric's scrape configuration, it may not be computed on the same interval as other metrics.
 	MetricsCache *MetricsCache
+
+	Valid bool
 }
 
 type MetricsCache struct {

--- a/site/docs/releases/changelog.md
+++ b/site/docs/releases/changelog.md
@@ -13,6 +13,7 @@ Our current priorities to support metrics for advanced database features and use
 
 - Updated project dependencies.
 - Standardize multi-arch builds and document supported database versions.
+- If the exporter fails to connect to a database due to invalid credentials (ORA-01017 error), that database configuration will be invalidated and the exporter will not attempt to re-establish the database connection. Other databases will continue to be scraped.
 - Metrics with an empty databases array (`databases = []`) are now considered disabled, and will not be scraped.
 - Increased the default query timeout for the `top_sql` metric to 10 seconds (previously 5 seconds).
 - Metrics using the `scrapeinterval` property will no longer be scraped on every request if they have a cached value. This only applies when the metrics exporter is configured to scrape metrics _on request_, rather than on a global interval.

--- a/site/docs/releases/roadmap.md
+++ b/site/docs/releases/roadmap.md
@@ -12,10 +12,10 @@ We welcome input on community-driven features you'd like to see supported. Pleas
 Currently, we plan to address the following key features:
 
 - Provide default Oracle Exadata metrics
-- Implement connection storm protection: prevent the exporter from repeatedly connecting when the credentials fail, to prevent a storm of connections causing accounts to be locked across a large number of databases
+- Provide default GoldenGate metrics
+- Enhance database alert logging and alert log metrics
 - Provide the option to have the Oracle client outside of the container image, e.g., on a shared volume,
 - Implement the ability to update the configuration dynamically, i.e., without a restart
 - Implement support for tracing within the database, e.g., using an execution context ID provide by an external caller
 - Provide additional pre-built Grafana dashboards,
 - Integration with Spring Observability, e.g., Micrometer
-- Provide additional documentation and samples


### PR DESCRIPTION
When the exporter fails to connect to the database with an ORA-01017 error (unauthorized, login failed), that database is _invalidated_, and the exporter will no longer attempt to scrape that database. A warning message is logged, identifying the invalid database configuration that must be fixed or removed.

The database is invalidated to prevent unnecessary connection attempts that are assumed to fail - which may lock out users or cause other unintended, unwanted consequences.