### PR TITLE
Various fixes; see changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ oci8.pc
 **/target/
 .DS_Store
 **/.cache/
+.gocache
 
 test-coverage.out
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,15 @@ ENV CGO_ENABLED=${CGO_ENABLED:-1}
 ARG GO_VERSION=1.26.2
 ENV GO_VERSION=${GO_VERSION}
 
-RUN microdnf install wget gzip gcc && \
-    wget -q https://go.dev/dl/go${GO_VERSION}.${GOOS}-${GOARCH}.tar.gz && \
+RUN microdnf install wget gzip gcc jq && \
+    go_tarball="go${GO_VERSION}.${GOOS}-${GOARCH}.tar.gz" && \
+    wget -q "https://go.dev/dl/${go_tarball}" && \
+    go_checksum="$(wget -qO- 'https://go.dev/dl/?mode=json' | jq -r --arg version "go${GO_VERSION}" --arg os "${GOOS}" --arg arch "${GOARCH}" '.[] | select(.version == $version) | .files[] | select(.os == $os and .arch == $arch) | .sha256' | head -n 1)" && \
+    test -n "${go_checksum}" && test "${go_checksum}" != "null" && \
+    printf '%s  %s\n' "${go_checksum}" "${go_tarball}" | sha256sum -c - && \
     rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go${GO_VERSION}.${GOOS}-${GOARCH}.tar.gz && \
-    rm go${GO_VERSION}.${GOOS}-${GOARCH}.tar.gz
+    tar -C /usr/local -xzf "${go_tarball}" && \
+    rm "${go_tarball}"
 
 ENV PATH=$PATH:/usr/local/go/bin
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ The exporter supports the following main features
 - Customize the database connection pool using go-sql, Oracle AI Database connection pools, and works with Database Resident Connection Pools
 - Includes a sample [Grafana dashboards](https://github.com/oracle/oracle-db-appdev-monitoring/tree/main/docker-compose/grafana) for inspiration or customization
 
+## Docker Compose Demo
+
+The `docker-compose/` stack is intended for local testing only.
+
+- Set `DB_PASSWORD` before starting it so the demo database, exporter sample configs, and TxEventQ load generator all use the same credential.
+- The sample database listeners are bound to `127.0.0.1` and should not be exposed on a shared or public host.
+
 ## Contributing
 
 This project welcomes contributions from the community. Before submitting a pull request, please [review our contribution guide](./CONTRIBUTING.md)

--- a/alertlog/alertlog.go
+++ b/alertlog/alertlog.go
@@ -36,6 +36,10 @@ var defaultLastLogRecord = LogRecord{
 	Timestamp: "1900-01-01T01:01:01.001Z",
 }
 
+const alertLogQuery = `select originating_timestamp, module_id, execution_context_id, message_text
+		from v$diag_alert_ext
+		where originating_timestamp > to_utc_timestamp_tz(:1)`
+
 // nullStringValue unwraps a nullable database string, returning an empty string for NULL.
 func nullStringValue(s sql.NullString) string {
 	if s.Valid {
@@ -144,6 +148,10 @@ func readLastMatchingLogRecord(logDestination, database string, perDatabaseFiles
 	return defaultLastLogRecord, nil
 }
 
+func buildAlertLogQuery(lastTimestamp string) (string, []interface{}) {
+	return alertLogQuery, []interface{}{lastTimestamp}
+}
+
 // UpdateLog appends newly queried alert log records for a database to the configured log destination.
 func UpdateLog(logDestination string, perDatabaseFiles bool, logger *slog.Logger, d *collector.Database) {
 	if !d.StartupReady() {
@@ -179,11 +187,8 @@ func UpdateLog(logDestination string, perDatabaseFiles bool, logger *slog.Logger
 	}
 
 	// query for any new alert log entries
-	stmt := fmt.Sprintf(`select originating_timestamp, module_id, execution_context_id, message_text
-		from v$diag_alert_ext
-		where originating_timestamp > to_utc_timestamp_tz('%s')`, lastLogRecord.Timestamp)
-
-	rows, unlock, err := d.Query(stmt)
+	stmt, args := buildAlertLogQuery(lastLogRecord.Timestamp)
+	rows, unlock, err := d.Query(stmt, args...)
 	if err != nil {
 		retryAfter := databaseRetries.recordFailure(d.Name, now)
 		logger.Error("Error querying the alert logs", "error", err, "database", d.Name, "retry_after", retryAfter)

--- a/alertlog/alertlog_test.go
+++ b/alertlog/alertlog_test.go
@@ -81,6 +81,25 @@ func TestRetryTrackerShouldRetry(t *testing.T) {
 	}
 }
 
+func TestBuildAlertLogQueryUsesBindVariable(t *testing.T) {
+	taintedTimestamp := "2000-01-01T00:00:00Z') union all select username,null,null,account_status from dba_users--"
+
+	stmt, args := buildAlertLogQuery(taintedTimestamp)
+
+	if strings.Contains(stmt, taintedTimestamp) {
+		t.Fatalf("expected tainted timestamp to stay out of SQL text, got %q", stmt)
+	}
+	if !strings.Contains(stmt, "to_utc_timestamp_tz(:1)") {
+		t.Fatalf("expected bind placeholder in alert log query, got %q", stmt)
+	}
+	if len(args) != 1 {
+		t.Fatalf("expected one bind argument, got %d", len(args))
+	}
+	if got := args[0]; got != taintedTimestamp {
+		t.Fatalf("expected tainted timestamp to be passed as bind arg, got %#v", got)
+	}
+}
+
 func TestReadLastMatchingLogRecord(t *testing.T) {
 	t.Run("shared log returns latest record for matching database", func(t *testing.T) {
 		logPath := filepath.Join(t.TempDir(), "alert.log")

--- a/build-all-macos.sh
+++ b/build-all-macos.sh
@@ -60,6 +60,7 @@ copy_workspace_to_container() {
 
   docker exec "${container}" rm -rf /oracle-db-appdev-monitoring
   docker cp "${SCRIPT_DIR}/." "${container}:/oracle-db-appdev-monitoring"
+  docker exec "${container}" rm -rf /oracle-db-appdev-monitoring/.git
 }
 
 linux_make_target() {
@@ -88,15 +89,20 @@ build_ol() {
   local container="build-${platform}"
   local filename="oracledb_exporter-${VERSION}.linux-${platform}.tar.gz"
   local make_target
+  local go_tarball="go${GO_VERSION}.linux-${platform}.tar.gz"
 
   make_target="$(linux_make_target "${platform}")"
 
   docker run -d --platform "linux/${platform}" --name "${container}" "${OL_IMAGE}" tail -f /dev/null
   copy_workspace_to_container "${container}"
-  docker exec "${container}" bash -c "dnf install -y wget git make gcc && \
-                                    wget -q https://go.dev/dl/go${GO_VERSION}.linux-${platform}.tar.gz && \
+  docker exec "${container}" bash -c "dnf install -y wget git make gcc jq && \
+                                    wget -q https://go.dev/dl/${go_tarball} && \
+                                    go_checksum=\"\$(wget -qO- 'https://go.dev/dl/?mode=json' | jq -r --arg version 'go${GO_VERSION}' --arg os 'linux' --arg arch '${platform}' '.[] | select(.version == \$version) | .files[] | select(.os == \$os and .arch == \$arch) | .sha256' | head -n 1)\" && \
+                                    test -n \"\${go_checksum}\" && test \"\${go_checksum}\" != \"null\" && \
+                                    printf '%s  %s\n' \"\${go_checksum}\" '${go_tarball}' | sha256sum -c - && \
                                     rm -rf /usr/local/go && \
-                                    tar -C /usr/local -xzf go${GO_VERSION}.linux-${platform}.tar.gz && \
+                                    tar -C /usr/local -xzf ${go_tarball} && \
+                                    rm ${go_tarball} && \
                                     export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin && \
                                     cd oracle-db-appdev-monitoring && \
                                     make ${make_target} VERSION=\"${VERSION}\" TAGS=\"${TAGS}\" CGO_ENABLED=\"${CGO_ENABLED}\""

--- a/build-all-macos.sh
+++ b/build-all-macos.sh
@@ -22,6 +22,7 @@ BUILD_CONTAINERS=""
 BUILD_DARWIN=""
 BUILD_UBUNTU=""
 BUILD_OL8=""
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 while getopts "v:t:cmuo" opt; do
   case ${opt} in
@@ -54,9 +55,26 @@ else
   CGO_ENABLED=1
 fi
 
+copy_workspace_to_container() {
+  local container="$1"
+
+  docker exec "${container}" rm -rf /oracle-db-appdev-monitoring
+  docker cp "${SCRIPT_DIR}/." "${container}:/oracle-db-appdev-monitoring"
+}
+
+linux_make_target() {
+  local platform="$1"
+
+  case "${platform}" in
+    amd64) echo "go-build-linux-amd64" ;;
+    arm64) echo "go-build-linux-arm64" ;;
+    *) echo "unsupported platform: ${platform}" >&2; exit 1 ;;
+  esac
+}
+
 build_darwin_local() {
-  echo "Build dawrin-arm64"
-  make go-build VERSION="$VERSION" TAGS="$TAGS" CGO_ENABLED="$CGO_ENABLED"
+  echo "Build darwin-arm64"
+  make go-build-darwin-arm64 VERSION="$VERSION" TAGS="$TAGS" CGO_ENABLED="$CGO_ENABLED"
   echo "Built for darwin-arm64"
 }
 
@@ -69,16 +87,19 @@ build_ol() {
   local platform="$1"
   local container="build-${platform}"
   local filename="oracledb_exporter-${VERSION}.linux-${platform}.tar.gz"
+  local make_target
+
+  make_target="$(linux_make_target "${platform}")"
 
   docker run -d --platform "linux/${platform}" --name "${container}" "${OL_IMAGE}" tail -f /dev/null
+  copy_workspace_to_container "${container}"
   docker exec "${container}" bash -c "dnf install -y wget git make gcc && \
                                     wget -q https://go.dev/dl/go${GO_VERSION}.linux-${platform}.tar.gz && \
                                     rm -rf /usr/local/go && \
                                     tar -C /usr/local -xzf go${GO_VERSION}.linux-${platform}.tar.gz && \
                                     export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin && \
-                                    git clone --depth 1 https://github.com/oracle/oracle-db-appdev-monitoring.git && \
                                     cd oracle-db-appdev-monitoring && \
-                                    make go-build VERSION=\"${VERSION}\" TAGS=\"${TAGS}\" CGO_ENABLED=\"${CGO_ENABLED}\""
+                                    make ${make_target} VERSION=\"${VERSION}\" TAGS=\"${TAGS}\" CGO_ENABLED=\"${CGO_ENABLED}\""
 
   docker cp "${container}:/oracle-db-appdev-monitoring/dist/${filename}" "dist/"
 
@@ -90,9 +111,9 @@ build_ol() {
 build_ubuntu() {
   local container="ubuntu-build"
   docker run -d --platform "linux/amd64" --name "${container}" "${UBUNTU_IMAGE}" tail -f /dev/null
+  copy_workspace_to_container "${container}"
   docker exec "${container}" bash -c "apt-get update -y && \
                                       apt-get -y install podman qemu-user-static golang gcc-aarch64-linux-gnu git make && \
-                                      git clone --depth 1 https://github.com/oracle/oracle-db-appdev-monitoring.git && \
                                       cd oracle-db-appdev-monitoring && \
                                       make go-build-linux-amd64 VERSION=\"${VERSION}\" TAGS=\"${TAGS}\" CGO_ENABLED=\"${CGO_ENABLED}\" && \
                                       make go-build-linux-gcc-arm64 VERSION=\"${VERSION}\" TAGS=\"${TAGS}\" CGO_ENABLED=\"${CGO_ENABLED}\""

--- a/collector/config.go
+++ b/collector/config.go
@@ -38,9 +38,12 @@ type MetricsConfiguration struct {
 }
 
 type WebConfig struct {
-	ListenAddresses *[]string `yaml:"listenAddresses"`
-	SystemdSocket   *bool     `yaml:"systemdSocket"`
-	ConfigFile      *string   `yaml:"configFile"`
+	ListenAddresses   *[]string      `yaml:"listenAddresses"`
+	SystemdSocket     *bool          `yaml:"systemdSocket"`
+	ConfigFile        *string        `yaml:"configFile"`
+	ReadHeaderTimeout *time.Duration `yaml:"readHeaderTimeout"`
+	ReadTimeout       *time.Duration `yaml:"readTimeout"`
+	IdleTimeout       *time.Duration `yaml:"idleTimeout"`
 }
 
 type DatabaseConfig struct {
@@ -142,6 +145,27 @@ func (m *MetricsConfiguration) LogPerDatabaseFiles() bool {
 
 func (m *MetricsConfiguration) ScrapeInterval() time.Duration {
 	return *m.Metrics.ScrapeInterval
+}
+
+func (wc WebConfig) GetReadHeaderTimeout() time.Duration {
+	if wc.ReadHeaderTimeout == nil {
+		return 10 * time.Second
+	}
+	return *wc.ReadHeaderTimeout
+}
+
+func (wc WebConfig) GetReadTimeout() time.Duration {
+	if wc.ReadTimeout == nil {
+		return 30 * time.Second
+	}
+	return *wc.ReadTimeout
+}
+
+func (wc WebConfig) GetIdleTimeout() time.Duration {
+	if wc.IdleTimeout == nil {
+		return 120 * time.Second
+	}
+	return *wc.IdleTimeout
 }
 
 func (m *MetricsConfiguration) CustomMetricsFiles() []string {

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -18,41 +18,46 @@ services:
     ports:
       - 3000:3000
     restart: unless-stopped
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=grafana
     volumes:
       - ./grafana/datasources:/etc/grafana/provisioning/datasources
       - ./grafana/dashboard.yaml:/etc/grafana/provisioning/dashboards/main.yaml
       - ./grafana/dashboards:/var/lib/grafana/dashboards
 
-  free23ai:
+  free26ai:
     image: gvenzl/oracle-free:23.26.1-slim-faststart
-    container_name: free23ai
+    container_name: free26ai
     ports:
-      - 1521:1521
+      - 127.0.0.1:1521:1521
     environment:
-      - ORACLE_PASSWORD=Welcome12345
+      - ORACLE_PASSWORD=${DB_PASSWORD}
     volumes:
       - ./oracle:/container-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "lsnrctl status | grep READY"]
+      test:
+        [
+          "CMD-SHELL",
+          "printf \"whenever sqlerror exit failure\\nset heading off feedback off pagesize 0 verify off\\nselect 'READY' from dual;\\nexit;\\n\" | sqlplus -s \"pdbadmin/$${ORACLE_PASSWORD}@//localhost:1521/FREEPDB1\" | grep -q READY",
+        ]
       interval: 15s
       timeout: 10s
       retries: 5
       start_period: 30s
 
-  second23ai:
+  second26ai:
     image: gvenzl/oracle-free:23.26.1-slim-faststart
-    container_name: second23ai
+    container_name: second26ai
     ports:
-      - 1522:1521
+      - 127.0.0.1:1522:1521
     environment:
-      - ORACLE_PASSWORD=Welcome12345
+      - ORACLE_PASSWORD=${DB_PASSWORD}
     volumes:
       - ./oracle:/container-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "lsnrctl status | grep READY"]
+      test:
+        [
+          "CMD-SHELL",
+          "printf \"whenever sqlerror exit failure\\nset heading off feedback off pagesize 0 verify off\\nselect 'READY' from dual;\\nexit;\\n\" | sqlplus -s \"pdbadmin/$${ORACLE_PASSWORD}@//localhost:1521/FREEPDB1\" | grep -q READY",
+        ]
       interval: 15s
       timeout: 10s
       retries: 5
@@ -62,7 +67,7 @@ services:
     image: container-registry.oracle.com/database/observability-exporter:2.3.0
     container_name: exporter
     command:
-      - --config.file=/exporter/${COMPOSE_CONFIG_FILE}
+      - --config.file=/exporter/${COMPOSE_CONFIG_FILE:-config.yaml}
       # - '--log.level=debug'
       # - '--database.maxIdleConns=10'
       # - '--database.maxOpenConns=10'
@@ -74,18 +79,19 @@ services:
     - ADB_USERNAME=${ADB_USERNAME}
     - ADB_PASSWORD=${ADB_PASSWORD}
     - ADB_TNS_ALIAS=${ADB_TNS_ALIAS}
+    - DB_PASSWORD=${DB_PASSWORD}
     #   - DB_USERNAME=pdbadmin
-    #   - DB_PASSWORD=Welcome12345
-    #   - DB_CONNECT_STRING=free23ai:1521/freepdb1
+    #   - DB_PASSWORD=${DB_PASSWORD}
+    #   - DB_CONNECT_STRING=free26ai:1521/freepdb1
     #   - CUSTOM_METRICS=/exporter/txeventq-metrics.toml,/exporter/more-txeventq-metrics.toml
     volumes:
       - ./exporter:/exporter
       - ./wallet:/exporter/wallet
 
     depends_on: 
-      free23ai:
+      free26ai:
         condition: service_healthy
-      second23ai:
+      second26ai:
         condition: service_healthy
 
 volumes:

--- a/docker-compose/exporter/config-with-scrape-interval.yaml
+++ b/docker-compose/exporter/config-with-scrape-interval.yaml
@@ -11,9 +11,9 @@ databases:
     ## Database username
     username: pdbadmin
     ## Database password
-    password: Welcome12345
+    password: ${DB_PASSWORD}
     ## Database connection url
-    url: free23ai:1521/freepdb1
+    url: free26ai:1521/freepdb1
 
     ## Metrics query timeout for this database, in seconds
     queryTimeout: 5
@@ -46,8 +46,8 @@ databases:
 
   second:
     username: pdbadmin
-    password: Welcome12345
-    url: second23ai:1521/freepdb1
+    password: ${DB_PASSWORD}
+    url: second26ai:1521/freepdb1
     queryTimeout: 5
     maxOpenConns: 10
     maxIdleConns: 10

--- a/docker-compose/exporter/config.yaml
+++ b/docker-compose/exporter/config.yaml
@@ -11,9 +11,9 @@ databases:
     ## Database username
     username: pdbadmin
     ## Database password
-    password: Welcome12345
+    password: ${DB_PASSWORD}
     ## Database connection url
-    url: free23ai:1521/freepdb1
+    url: free26ai:1521/freepdb1
 
     ## Metrics query timeout for this database, in seconds
     queryTimeout: 5
@@ -46,8 +46,8 @@ databases:
 
   second:
     username: pdbadmin
-    password: Welcome12345
-    url: second23ai:1521/freepdb1
+    password: ${DB_PASSWORD}
+    url: second26ai:1521/freepdb1
     queryTimeout: 5
     maxOpenConns: 10
     maxIdleConns: 10

--- a/docker-compose/oracle/grant_permissions.sh
+++ b/docker-compose/oracle/grant_permissions.sh
@@ -1,5 +1,9 @@
+#!/bin/sh
+set -eu
+
+sqlplus -s / as sysdba <<EOF
 alter session set container=freepdb1;
-alter user pdbadmin identified by "Welcome12345";
+alter user pdbadmin identified by "${ORACLE_PASSWORD}";
 grant unlimited tablespace to pdbadmin;
 grant select_catalog_role to pdbadmin;
 grant execute on dbms_aq to pdbadmin;
@@ -8,6 +12,8 @@ grant execute on dbms_aqin to pdbadmin;
 grant execute on dbms_aqjms_internal to pdbadmin;
 grant execute on dbms_teqk to pdbadmin;
 grant execute on DBMS_RESOURCE_MANAGER to pdbadmin;
-grant select on sys.aq$_queue_shards to pdbadmin;
-grant select on sys.v_$diag_alert_ext to pdbadmin;
+grant select on sys.aq\$_queue_shards to pdbadmin;
+grant select on sys.v_\$diag_alert_ext to pdbadmin;
 grant select on user_queue_partition_assignment_table to pdbadmin;
+exit;
+EOF

--- a/docker-compose/txeventq-load/src/main/resources/application.yaml
+++ b/docker-compose/txeventq-load/src/main/resources/application.yaml
@@ -6,9 +6,9 @@ spring:
       enabled: true
 
   datasource:
-    url: jdbc:oracle:thin:@//172.23.0.2:1521/freepdb1
-    username: system
-    password: Welcome12345
+    url: ${DB_URL:jdbc:oracle:thin:@//localhost:1521/freepdb1}
+    username: ${DB_USERNAME:system}
+    password: ${DB_PASSWORD}
     driver-class-name: oracle.jdbc.OracleDriver
     type: oracle.ucp.jdbc.PoolDataSource
     oracleucp:

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -60,3 +60,11 @@ log:
   interval: 15s
   ## Set disable to 1 to disable logging
   # disable: 0
+
+web:
+  ## Optional exporter HTTP server settings.
+  # listenAddresses: [':9161']
+  # configFile: /path/to/web-config.yml
+  # readHeaderTimeout: 10s
+  # readTimeout: 30s
+  # idleTimeout: 120s

--- a/hashivault/hashivault.go
+++ b/hashivault/hashivault.go
@@ -121,10 +121,7 @@ func (c HashicorpVaultClient) getVaultSecret(mountType string, mount string, pat
 		c.logger.Error(UnsupportedMountType.Error())
 		return result, UnsupportedMountType
 	}
-	// Expect simple one-level JSON, remap interface{} straight to string
-	for key, val := range secretData {
-		result[key] = strings.TrimRight(val.(string), "\r\n") // make sure a \r and/or \n didn't make it into the secret
-	}
+	c.copyStringSecretData(result, secretData)
 	// Check that we have all required keys present
 	for _, key := range requiredKeys {
 		val, keyExists := result[key]
@@ -139,4 +136,15 @@ func (c HashicorpVaultClient) getVaultSecret(mountType string, mount string, pat
 // GetVaultSecret fetches secret from vault using specified mount type.
 func (c HashicorpVaultClient) GetVaultSecret(mountType string, mount string, path string, requiredKeys []string) (map[string]string, error) {
 	return c.getVaultSecret(mountType, mount, path, requiredKeys)
+}
+
+func (c HashicorpVaultClient) copyStringSecretData(result map[string]string, secretData map[string]interface{}) {
+	for key, val := range secretData {
+		strVal, ok := val.(string)
+		if !ok {
+			c.logger.Warn("Skipping non-string HashiCorp Vault secret value", "key", key, "type", fmt.Sprintf("%T", val))
+			continue
+		}
+		result[key] = strings.TrimRight(strVal, "\r\n") // make sure a \r and/or \n didn't make it into the secret
+	}
 }

--- a/hashivault/hashivault_test.go
+++ b/hashivault/hashivault_test.go
@@ -6,6 +6,7 @@ package hashivault
 import (
 	"io"
 	"log/slog"
+	"reflect"
 	"testing"
 )
 
@@ -21,5 +22,53 @@ func TestCreateVaultClientFallsBackToDefaultConfigWithoutProxySocket(t *testing.
 	}
 	if client.client == nil {
 		t.Fatal("expected non-nil client when proxy socket is not configured")
+	}
+}
+
+func TestCopyStringSecretDataIgnoresNonStringValues(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := HashicorpVaultClient{logger: logger}
+
+	result := map[string]string{}
+	client.copyStringSecretData(result, map[string]interface{}{
+		"username": "scott\n",
+		"password": "tiger\r\n",
+		"ttl":      3600,
+		"enabled":  true,
+		"metadata": map[string]interface{}{"env": "dev"},
+		"null":     nil,
+	})
+
+	want := map[string]string{
+		"username": "scott",
+		"password": "tiger",
+	}
+	if !reflect.DeepEqual(result, want) {
+		t.Fatalf("unexpected remapped secret data: got %#v want %#v", result, want)
+	}
+}
+
+func TestCopyStringSecretDataLeavesRequiredKeyValidationToCaller(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := HashicorpVaultClient{logger: logger}
+
+	result := map[string]string{}
+	client.copyStringSecretData(result, map[string]interface{}{
+		"username": "scott",
+		"ttl":      3600,
+	})
+
+	requiredKeys := []string{"username", "password"}
+	for _, key := range requiredKeys {
+		val, ok := result[key]
+		if key == "password" {
+			if ok || val != "" {
+				t.Fatalf("expected missing required key %q after filtering non-string values, got ok=%v val=%q", key, ok, val)
+			}
+			continue
+		}
+		if !ok || val == "" {
+			t.Fatalf("expected required key %q to remain present, got ok=%v val=%q", key, ok, val)
+		}
 	}
 }

--- a/kubernetes/metrics-exporter-deployment.yaml
+++ b/kubernetes/metrics-exporter-deployment.yaml
@@ -1,4 +1,4 @@
-## Copyright (c) 2021, 2023, Oracle and/or its affiliates.
+## Copyright (c) 2021, 2026, Oracle and/or its affiliates.
 ## Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 apiVersion: apps/v1
 kind: Deployment
@@ -15,12 +15,25 @@ spec:
       labels:
         app: metrics-exporter
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: metrics-exporter
-        image: container-registry.oracle.com/database/observability-exporter:2.0.2
-        imagePullPolicy: Always
+        # Replace with the published digest for the release you intend to run, for example:
+        # image: container-registry.oracle.com/database/observability-exporter:2.3.0@sha256:<published-digest>
+        image: container-registry.oracle.com/database/observability-exporter:2.3.0
+        imagePullPolicy: IfNotPresent
         command: ["/oracledb_exporter"]
         args: ["--config.file=/config/metrics-exporter-config.yaml"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
         env:
           # uncomment and customize the next item if you want to provide custom metrics definitions
           #- name: CUSTOM_METRICS
@@ -45,8 +58,12 @@ spec:
         volumeMounts:
           - name: exporter-config
             mountPath: /config
+            readOnly: true
           - name: tns-admin
             mountPath: /oracle/tns_admin
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
           # uncomment and customize the next item if you want to provide custom metrics definitions
           #- name: config-volume
           #  mountPath: /oracle/observability/txeventq-metrics.toml
@@ -59,7 +76,7 @@ spec:
             memory: "128Mi"
             cpu: "500m"  
         ports:
-        - containerPort: 8080
+        - containerPort: 9161
       restartPolicy: Always
       volumes:
         - name: tns-admin
@@ -68,6 +85,8 @@ spec:
         - name: exporter-config
           configMap:
             name: metrics-exporter-config
+        - name: tmp
+          emptyDir: {}
         # uncomment and customize the next item if you want to provide custom metrics definitions
         #- name: config-volume
         #  configMap:

--- a/kubernetes/metrics-exporter-network-policy.yaml
+++ b/kubernetes/metrics-exporter-network-policy.yaml
@@ -1,0 +1,19 @@
+## Copyright (c) 2026, Oracle and/or its affiliates.
+## Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: metrics-exporter-ingress
+  namespace: exporter
+spec:
+  podSelector:
+    matchLabels:
+      app: metrics-exporter
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 9161

--- a/main.go
+++ b/main.go
@@ -221,7 +221,11 @@ func main() {
 		}()
 	}
 
-	server := &http.Server{}
+	server := &http.Server{
+		ReadHeaderTimeout: m.Web.GetReadHeaderTimeout(),
+		ReadTimeout:       m.Web.GetReadTimeout(),
+		IdleTimeout:       m.Web.GetIdleTimeout(),
+	}
 	serverErr := make(chan error, 1)
 	go func() {
 		serverErr <- web.ListenAndServe(server, m.Web.Flags(), logger)

--- a/site/docs/advanced/txeventq.md
+++ b/site/docs/advanced/txeventq.md
@@ -78,9 +78,10 @@ end;
 
 A simple load generator is provided in [this directory](https://github.com/oracle/oracle-db-appdev-monitoring/tree/main/docker-compose/txeventq-load) which you can use to create some traffic so you can experiment with the sample dashboard.
 
-To run the sample, first update [application.yaml](https://github.com/oracle/oracle-db-appdev-monitoring/blob/main/docker-compose/txeventq-load/src/main/resources/application.yaml) with the correct IP address for your database, then start the application as follows:
+To run the sample, set `DB_PASSWORD` and, if needed, override `DB_URL` or `DB_USERNAME` for your environment before starting the application.  The default URL targets a local database at `localhost:1521/freepdb1`.
 
 ```bash
+export DB_PASSWORD='<your-demo-password>'
 mvn spring-boot:run
 ```
 

--- a/site/docs/configuration/config-file.md
+++ b/site/docs/configuration/config-file.md
@@ -97,6 +97,9 @@ log:
 #  listenAddresses: [':9161']
 #  systemdSocket: true|false
 #  configFile: /path/to/webconfigfile
+#  readHeaderTimeout: 10s
+#  readTimeout: 30s
+#  idleTimeout: 120s
 ```
 
 From the exporter configuration file, you may optionally load database credentials from [OCI Vault](./oci-vault.md), [Azure Vault](./azure-vault.md), or [HashiCorp Vault](./hashicorp-vault.md).
@@ -110,6 +113,9 @@ web:
   listenAddresses: [':9161']
   systemdSocket: false
   configFile: /etc/metrics-exporter/web-config.yml
+  readHeaderTimeout: 10s
+  readTimeout: 30s
+  idleTimeout: 120s
 ```
 
 The `web` properties are:
@@ -117,6 +123,9 @@ The `web` properties are:
 - `listenAddresses`: One or more addresses for the exporter HTTP server to bind to. For example, `[':9161']` listens on port `9161` on all interfaces.
 - `systemdSocket`: Enables systemd socket activation. When set to `true`, systemd provides the listening socket.
 - `configFile`: Path to a Prometheus Exporter Toolkit web configuration file. Configure TLS, basic authentication, and other supported web server features in this file.
+- `readHeaderTimeout`: Maximum time to read request headers. Defaults to `10s`.
+- `readTimeout`: Maximum time to read the full HTTP request. Defaults to `30s`.
+- `idleTimeout`: Maximum time to wait for the next request on a keep-alive connection. Defaults to `120s`.
 
 Configure web server security settings such as TLS and basic authentication through `web.configFile`. Those settings should be defined in the Prometheus Exporter Toolkit configuration file, not as exporter-specific properties in the main exporter config file.
 

--- a/site/docs/configuration/oracle-wallet.md
+++ b/site/docs/configuration/oracle-wallet.md
@@ -78,7 +78,7 @@ If you are running the exporter as a container, you can mount the wallet as a vo
 ```bash
 docker run -it --rm \
     -e DB_USERNAME=pdbadmin \
-    -e DB_PASSWORD=Welcome12345 \
+    -e DB_PASSWORD='<your-password>' \
     -e DB_CONNECT_STRING=devdb_tp \
     -v ./wallet:/wallet \
     -p 9161:9161 \

--- a/site/docs/getting-started/basics.md
+++ b/site/docs/getting-started/basics.md
@@ -156,6 +156,8 @@ The following example puts the logfile in the current location with the filename
 
 If you prefer to provide configuration via a [config file](../configuration/config-file.md), you may do so with the `--config.file` argument. The use of a config file over command line arguments is preferred. If a config file is not provided, the "default" database connection is managed by command line arguments.
 
+HTTP server request timeouts are configured in the exporter config file under `web.readHeaderTimeout`, `web.readTimeout`, and `web.idleTimeout`.
+
 ```yaml
 # Example Oracle AI Database Metrics Exporter Configuration file.
 # Environment variables of the form ${VAR_NAME} will be expanded.

--- a/site/docs/getting-started/basics.md
+++ b/site/docs/getting-started/basics.md
@@ -50,7 +50,7 @@ If you need an Oracle AI Database to test the exporter, you can use this command
 docker run --name free23ai \
     -d \
     -p 1521:1521 \
-    -e ORACLE_PASSWORD=Welcome12345 \
+    -e ORACLE_PASSWORD='<your-password>' \
     gvenzl/oracle-free:23.9-slim-faststart
 ```
 
@@ -86,7 +86,7 @@ You need to give the exporter the connection details for the Oracle AI Database 
 For a simple connection, you will provide the details using these variables:
 
 - `DB_USERNAME` is the database username, e.g., `pdbadmin`
-- `DB_PASSWORD` is the password for that user, e.g., `Welcome12345`
+- `DB_PASSWORD` is the password for that user, e.g., `<your-password>`
 - `DB_CONNECT_STRING` is the connection string, e.g., `free23ai:1521/freepdb`
 - `DB_ROLE` (Optional) can be set to `SYSDBA`, `SYSOPER`, `SYSBACKUP`, `SYSDG`, `SYSKM`, `SYSRAC` or `SYSASM` if you want to connect with one of those roles, however Oracle recommends that you connect with the lowest possible privileges and roles necessary for the exporter to run.
 
@@ -95,7 +95,7 @@ To run the exporter in a container and expose the port, use a command like this,
 ```bash
 docker run -it --rm \
     -e DB_USERNAME=pdbadmin \
-    -e DB_PASSWORD=Welcome12345 \
+    -e DB_PASSWORD='<your-password>' \
     -e DB_CONNECT_STRING=free23ai:1521/freepdb \
     -p 9161:9161 \
     container-registry.oracle.com/database/observability-exporter:2.3.0
@@ -146,7 +146,7 @@ Usage of oracledb_exporter:
 You may provide the connection details using these variables:
 
 - `DB_USERNAME` is the database username, e.g., `pdbadmin`
-- `DB_PASSWORD` is the password for that user, e.g., `Welcome12345`
+- `DB_PASSWORD` is the password for that user, e.g., `<your-password>`
 - `DB_CONNECT_STRING` is the connection string, e.g., `localhost:1521/freepdb1`
 - `DB_ROLE` (Optional) can be set to `SYSDBA` or `SYSOPER` if you want to connect with one of those roles, however Oracle recommends that you connect with the lowest possible privileges and roles necessary for the exporter to run.
 - `ORACLE_HOME` is the location of the Oracle Instant Client, e.g., `/lib/oracle/21/client64/lib`.
@@ -250,13 +250,15 @@ log:
 If you would like to set up a test environment with the exporter, you can use the provided "Docker Compose" file in this repository which will start an Oracle AI Database instance, the exporter, Prometheus and Grafana.
 
 ```bash
-make docker-compose-up
+DB_PASSWORD='<choose-a-local-demo-password>' make docker-compose-up
 ```
 
 The containers will take a short time to start.  The first time, the Oracle container might take a few minutes to start while it creates the database instance, but this is a one-time operation, and subequent restarts will be much faster (a few seconds).
+
+> Warning: This stack is intended for local testing only.  Set `DB_PASSWORD` explicitly before startup, and keep the sample database ports bound to `127.0.0.1` rather than exposing them on a shared or public host.
 
 Once the containers are all running, you can access the services using these URLs:
 
 - [Exporter](http://localhost:9161/metrics)
 - [Prometheus](http://localhost:9090) - try a query for "oracle".
-- [Grafana](http://localhost:3000) - username is "admin" and password is "grafana".  An Oracle AI Database dashboard is provisioned and configured to use data from the exporter.
+- [Grafana](http://localhost:3000) - Grafana uses its first-login initialization flow, and an Oracle AI Database dashboard is provisioned and configured to use data from the exporter.

--- a/site/docs/getting-started/kubernetes.md
+++ b/site/docs/getting-started/kubernetes.md
@@ -61,13 +61,15 @@ kubectl create cm db-metrics-txeventq-exporter-config \
 
 ### Deploy the Oracle AI Database Observability exporter
 
-A sample Kubernetes manifest is provided [here](https://github.com/oracle/oracle-db-appdev-monitoring/blob/main/kubernetes/metrics-exporter-deployment.yaml).  You must edit this file to set the namespace you wish to use, the database connect string to use, and if you have any custom metrics, you will need to uncomment and customize some sections in this file.
+A sample Kubernetes manifest is provided [here](https://github.com/oracle/oracle-db-appdev-monitoring/blob/main/kubernetes/metrics-exporter-deployment.yaml).  You must edit this file to set the namespace you wish to use, the database connect string to use, and if you have any custom metrics, you will need to uncomment and customize some sections in this file.  Before applying the manifest, replace the sample image reference with the published digest for the exporter release you intend to run.
 
 Once you have made the necessary updates, apply the file to your cluster using this command:
 
 ```bash
 kubectl apply -f metrics-exporter-deployment.yaml
 ```
+
+The sample deployment runs with a non-root pod and container security context, a read-only root filesystem, and a writable `/tmp` volume for temporary files.
 
 You can check the deployment was successful and monitor the exporter startup with this command:
 
@@ -99,6 +101,14 @@ Once you have made any necessary udpates, apply the file to your cluster using t
 
 ```bash
 kubectl apply -f metrics-service-monitor.yaml
+```
+
+### Create a NetworkPolicy for metrics ingress
+
+Create a Kubernetes NetworkPolicy to limit ingress to the exporter metrics port.  A sample Kubernetes manifest is provided [here](https://github.com/oracle/oracle-db-appdev-monitoring/blob/main/kubernetes/metrics-exporter-network-policy.yaml).  The sample allows TCP ingress on port `9161` from pods in the same namespace; update the selectors if your Prometheus deployment scrapes from a different namespace.
+
+```bash
+kubectl apply -f metrics-exporter-network-policy.yaml
 ```
 
 ### Configure a Prometheus target (optional)

--- a/site/docs/getting-started/kubernetes.md
+++ b/site/docs/getting-started/kubernetes.md
@@ -11,12 +11,12 @@ To run the exporter in Kubernetes, you must complete the following steps.  All s
 
 ### Create a secret with credentials for connecting to the Oracle AI Database
 
-Create a secret with the Oracle AI Database user and password that the exporter should use to connect to the database using this command.  You must specify the correct user and password for your environment.  This example uses `pdbadmin` as the user and `Welcome12345` as the password:
+Create a secret with the Oracle AI Database user and password that the exporter should use to connect to the database using this command.  You must specify the correct user and password for your environment.  This example uses `pdbadmin` as the user and `<your-password>` as the password:
 
 ```bash
 kubectl create secret generic db-secret \
     --from-literal=username=pdbadmin \
-    --from-literal=password=Welcome12345 \
+    --from-literal=password='<your-password>' \
     -n exporter
 ```
 

--- a/site/docs/releases/changelog.md
+++ b/site/docs/releases/changelog.md
@@ -9,6 +9,8 @@ List of upcoming and historic changes to the exporter.
 
 ### Next, TBD
 
+- Harden the sample Kubernetes deployment with restrictive pod and container security contexts, switch it to `IfNotPresent`, and add a sample NetworkPolicy for ingress to port `9161`.
+- Set HTTP server read-header, read, and idle timeouts before handing the listener to the Prometheus exporter toolkit, and expose those timeout defaults through the exporter config file.
 - Pin the demo Docker Compose `prom/prometheus` and `grafana/grafana` images to immutable digests instead of floating tags.
 - Fall back to the default HashiCorp Vault client configuration when `vault.hashicorp.proxySocket` is not configured, preventing a nil-pointer panic while still allowing environment-based Vault configuration.
 - Remove production use of the OCI SDK `example/helpers` package in Vault integrations so OCI Vault and HashiCorp Vault lookup failures return errors instead of terminating the exporter process.
@@ -22,6 +24,9 @@ List of upcoming and historic changes to the exporter.
 - Add the exporter release `version` label to `oracledb_exporter_build_info`, matching the standard Prometheus build info metric shape.
 - Add an initial GitHub Actions workflow to run `make go-test` and `make go-build` on approved pull requests targeting `main` and on pushes to `main`.
 - Add `CODEOWNERS` protection for GitHub workflow files.
+- Ignore non-string values returned from HashiCorp Vault secret payloads instead of panicking, so malformed or structured KV data cannot crash the exporter.
+- Verify downloaded Go toolchain tarballs against the published SHA256 in the Docker build and macOS release script before extracting them.
+- Use a bind variable for the alert-log timestamp query instead of interpolating the last on-disk timestamp into SQL text.
 
 Thank you to the following users for their suggestions and contributions:
 - [jens-ho](https://github.com/jens-ho)


### PR DESCRIPTION
- Improve release build reliability by copying the checked-out workspace into the build script instead of cloning the remote
    repository again.
- Harden supply-chain handling by verifying downloaded Go binaries with SHA checks before use.
- Fix a HashiCorp Vault secret loading bug caused by unexpected non-string values.
- Harden the Kubernetes example manifests with safer default security settings.
- Add configurable HTTP server timeouts for the exporter.
- Use a bind variable in the alert log query instead of interpolating values into SQL text.
- Clean up the Docker Compose demo scripts and remove hardcoded demo passwords.