### PR TITLE
Notify scrape when ready

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -70,7 +70,7 @@ func NewExporter(logger *slog.Logger, m *MetricsConfiguration) *Exporter {
 	e := &Exporter{
 		mu:                  &sync.Mutex{},
 		customMetricsHashes: map[string][]byte{},
-		scrapeRequests:      make(chan struct{}, len(databases)+1),
+		scrapeRequests:      make(chan struct{}, 1),
 		duration: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: exporterName,

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -70,6 +70,7 @@ func NewExporter(logger *slog.Logger, m *MetricsConfiguration) *Exporter {
 	e := &Exporter{
 		mu:                  &sync.Mutex{},
 		customMetricsHashes: map[string][]byte{},
+		scrapeRequests:      make(chan struct{}, len(databases)+1),
 		duration: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: exporterName,
@@ -121,6 +122,7 @@ func (e *Exporter) InitializeDatabases() {
 		if err := database.WarmupConnectionPool(e.logger, e.MetricsConfiguration.ConnectionBackoff()); err != nil {
 			e.logger.Error("Database startup warmup failed", "error", err, "database", database.Name)
 		}
+		e.requestScheduledScrape()
 	}
 }
 
@@ -168,7 +170,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	// they are running scheduled scrapes we should only scrape new data
 	// on the interval
-	if e.ScrapeInterval() != 0 {
+	if e.scrapeInterval() != 0 {
 		// read access must be checked
 		e.mu.Lock()
 		for _, r := range e.scrapeResults {
@@ -196,9 +198,14 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 // RunScheduledScrapes is only relevant for users of this package that want to set the scrape on a timer
 // rather than letting it be per Collect call
 func (e *Exporter) RunScheduledScrapes(ctx context.Context) {
+	interval := e.scrapeInterval()
+	if interval == 0 {
+		return
+	}
+
 	e.doScrape(time.Now())
 
-	ticker := time.NewTicker(e.ScrapeInterval())
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -206,10 +213,32 @@ func (e *Exporter) RunScheduledScrapes(ctx context.Context) {
 		case tick := <-ticker.C:
 
 			e.doScrape(tick)
+		case <-e.scrapeRequests:
+			e.doScrape(time.Now())
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+func (e *Exporter) requestScheduledScrape() {
+	if e.scrapeInterval() == 0 || e.scrapeRequests == nil {
+		return
+	}
+
+	// Do not let database warmup block on the scheduler. If a scrape is already queued,
+	// the next scheduled scrape will pick up all databases that are ready by then.
+	select {
+	case e.scrapeRequests <- struct{}{}:
+	default:
+	}
+}
+
+func (e *Exporter) scrapeInterval() time.Duration {
+	if e.MetricsConfiguration == nil || e.MetricsConfiguration.Metrics.ScrapeInterval == nil {
+		return 0
+	}
+	return e.ScrapeInterval()
 }
 
 func (e *Exporter) doScrape(tick time.Time) {

--- a/collector/database_test.go
+++ b/collector/database_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -315,4 +316,162 @@ func TestScrapeDatabaseSkipsWhileStartupInProgress(t *testing.T) {
 		t.Fatal("did not expect metrics while startup is in progress")
 	default:
 	}
+}
+
+func TestRunScheduledScrapesRunsWhenDatabaseBecomesReady(t *testing.T) {
+	exporter, database := newTestScheduledExporter(t, time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go exporter.RunScheduledScrapes(ctx)
+	waitForScheduledScrape(t, exporter)
+
+	if hasScheduledMetric(exporter, "oracledb_test_value") {
+		t.Fatal("did not expect test metric before database startup is ready")
+	}
+
+	database.startupReady.Store(true)
+	database.setUp(1)
+	exporter.requestScheduledScrape()
+
+	waitForScheduledMetric(t, exporter, "oracledb_test_value")
+}
+
+func TestInitializeDatabasesRequestsScheduledScrapeAfterWarmup(t *testing.T) {
+	exporter, database := newTestScheduledExporter(t, time.Hour)
+
+	exporter.InitializeDatabases()
+
+	if !database.StartupReady() {
+		t.Fatal("expected database startup to be marked ready after warmup")
+	}
+	if got := len(exporter.scrapeRequests); got != 1 {
+		t.Fatalf("expected one scheduled scrape request after warmup, got %d", got)
+	}
+}
+
+func newTestScheduledExporter(t *testing.T, scrapeInterval time.Duration) (*Exporter, *Database) {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	metric := &Metric{
+		ID:          "test_value",
+		Context:     "test",
+		MetricsDesc: map[string]string{"value": "Test metric."},
+		MetricsType: map[string]string{"value": "gauge"},
+		Request:     "select 1 as value from dual",
+	}
+	metricsToScrape := map[string]*Metric{
+		metric.ID: metric,
+	}
+	maxOpenConns := 1
+	database := &Database{
+		Name:          "db1",
+		Session:       openTestQueryDB(t),
+		Config:        DatabaseConfig{ConnectConfig: ConnectConfig{MaxOpenConns: &maxOpenConns}},
+		DatabaseLabel: "database",
+	}
+	database.initCache(metricsToScrape)
+
+	return &Exporter{
+		mu:              &sync.Mutex{},
+		metricsToScrape: metricsToScrape,
+		duration: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "last_scrape_duration_seconds",
+			Help:      "test",
+		}),
+		databaseDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "last_database_scrape_duration_seconds",
+			Help:      "test",
+		}, []string{"database"}),
+		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "scrapes_total",
+			Help:      "test",
+		}),
+		error: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "last_scrape_error",
+			Help:      "test",
+		}),
+		scrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "scrape_errors_total",
+			Help:      "test",
+		}, []string{"collector", "database"}),
+		scrapeRequests: make(chan struct{}, 2),
+		databases:      []*Database{database},
+		logger:         logger,
+		MetricsConfiguration: &MetricsConfiguration{
+			Metrics: MetricsFilesConfig{
+				DatabaseLabel:  "database",
+				ScrapeInterval: &scrapeInterval,
+			},
+		},
+	}, database
+}
+
+func waitForScheduledScrape(t *testing.T, exporter *Exporter) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		if len(collectScheduledMetrics(exporter)) > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for scheduled scrape")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func waitForScheduledMetric(t *testing.T, exporter *Exporter, fqName string) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		if hasScheduledMetric(exporter, fqName) {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for scheduled metric %q", fqName)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func hasScheduledMetric(exporter *Exporter, fqName string) bool {
+	for _, desc := range collectScheduledMetrics(exporter) {
+		if strings.Contains(desc, `fqName: "`+fqName+`"`) {
+			return true
+		}
+	}
+	return false
+}
+
+func collectScheduledMetrics(exporter *Exporter) []string {
+	ch := make(chan prometheus.Metric)
+	done := make(chan []string, 1)
+
+	go func() {
+		var descs []string
+		for metric := range ch {
+			descs = append(descs, metric.Desc().String())
+		}
+		done <- descs
+	}()
+
+	exporter.Collect(ch)
+	close(ch)
+	return <-done
 }

--- a/collector/database_test.go
+++ b/collector/database_test.go
@@ -406,7 +406,7 @@ func newTestScheduledExporter(t *testing.T, scrapeInterval time.Duration) (*Expo
 			Name:      "scrape_errors_total",
 			Help:      "test",
 		}, []string{"collector", "database"}),
-		scrapeRequests: make(chan struct{}, 2),
+		scrapeRequests: make(chan struct{}, 1),
 		databases:      []*Database{database},
 		logger:         logger,
 		MetricsConfiguration: &MetricsConfiguration{

--- a/collector/types.go
+++ b/collector/types.go
@@ -23,6 +23,7 @@ type Exporter struct {
 	totalScrapes        prometheus.Counter
 	scrapeErrors        *prometheus.CounterVec
 	scrapeResults       []prometheus.Metric
+	scrapeRequests      chan struct{}
 	databases           []*Database
 	logger              *slog.Logger
 	allConstLabels      []string

--- a/site/docs/releases/changelog.md
+++ b/site/docs/releases/changelog.md
@@ -10,7 +10,10 @@ List of upcoming and historic changes to the exporter.
 ### Next, TBD
 
 - Remove deprecated runtime configuration flags other than `--config.file`; exporter startup now requires a YAML config file, and process log `level` and `format` are configured under the `log` section.
-- Fix scheduled scraping so a database is scraped immediately after startup warmup completes when `metrics.scrapeInterval` is configured, restoring first-scrape behavior from #166. Thanks @gjrlopes for reporting #532.
+- Fix scheduled scraping so a database is scraped immediately after startup warmup completes when `metrics.scrapeInterval` is configured.
+
+Thank you to the following users for their suggestions and contributions:
+- [gjrlopes](https://github.com/gjrlopes)
 
 ### 2.3.1, May 6th, 2026
 

--- a/site/docs/releases/changelog.md
+++ b/site/docs/releases/changelog.md
@@ -10,6 +10,7 @@ List of upcoming and historic changes to the exporter.
 ### Next, TBD
 
 - Remove deprecated runtime configuration flags other than `--config.file`; exporter startup now requires a YAML config file, and process log `level` and `format` are configured under the `log` section.
+- Fix scheduled scraping so a database is scraped immediately after startup warmup completes when `metrics.scrapeInterval` is configured, restoring first-scrape behavior from #166. Thanks @gjrlopes for reporting #532.
 
 ### 2.3.1, May 6th, 2026
 


### PR DESCRIPTION
when running in scheduled scrape mode, the exporter will notify the scrape routine once the databases are ready. This prevents the first scrape from coming up empty. 