### PR TITLE
Fixing bugs

### DIFF
--- a/collector/config.go
+++ b/collector/config.go
@@ -361,7 +361,11 @@ func (m *MetricsConfiguration) merge() {
 
 func (m *MetricsConfiguration) mergeWebConfig() {
 	if m.Web.ListenAddresses == nil {
-		listenAddresses := []string{":9161"}
+		listenAddress := strings.TrimSpace(m.ListenAddress)
+		if listenAddress == "" {
+			listenAddress = ":9161"
+		}
+		listenAddresses := []string{listenAddress}
 		m.Web.ListenAddresses = &listenAddresses
 	}
 	if m.Web.SystemdSocket == nil {

--- a/collector/config_test.go
+++ b/collector/config_test.go
@@ -152,6 +152,49 @@ databases:
 	}
 }
 
+func TestLoadMetricsConfigurationMapsLegacyListenAddressToWebConfig(t *testing.T) {
+	configPath := writeExporterConfig(t, `
+listenAddress: 127.0.0.1:9161
+databases:
+  default:
+    username: scott
+    password: tiger
+    url: localhost:1521/freepdb1
+`)
+
+	cfg, err := LoadMetricsConfiguration(testLogger(), &Config{ConfigFile: configPath})
+	if err != nil {
+		t.Fatalf("expected config to load, got %v", err)
+	}
+
+	if got := *cfg.Web.ListenAddresses; len(got) != 1 || got[0] != "127.0.0.1:9161" {
+		t.Fatalf("expected legacy listenAddress to configure web listen address, got %#v", got)
+	}
+}
+
+func TestLoadMetricsConfigurationPrefersWebListenAddresses(t *testing.T) {
+	configPath := writeExporterConfig(t, `
+listenAddress: 127.0.0.1:9161
+web:
+  listenAddresses:
+    - 127.0.0.1:9162
+databases:
+  default:
+    username: scott
+    password: tiger
+    url: localhost:1521/freepdb1
+`)
+
+	cfg, err := LoadMetricsConfiguration(testLogger(), &Config{ConfigFile: configPath})
+	if err != nil {
+		t.Fatalf("expected config to load, got %v", err)
+	}
+
+	if got := *cfg.Web.ListenAddresses; len(got) != 1 || got[0] != "127.0.0.1:9162" {
+		t.Fatalf("expected web.listenAddresses to take precedence, got %#v", got)
+	}
+}
+
 func TestLoadMetricsConfigurationAcceptsLogLevelAndFormat(t *testing.T) {
 	configPath := writeExporterConfig(t, `
 databases:

--- a/collector/connect_godror.go
+++ b/collector/connect_godror.go
@@ -86,6 +86,18 @@ func connect(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) (*sql.
 	return db, nil
 }
 
+func effectiveSQLPoolLimits(dbconfig DatabaseConfig) (int, int) {
+	return dbconfig.GetMaxOpenConns(), dbconfig.GetMaxIdleConns()
+}
+
+func warmupConnectionPoolSize(dbconfig DatabaseConfig) int {
+	poolSize := dbconfig.GetMaxOpenConns()
+	if poolSize < 1 {
+		poolSize = dbconfig.GetPoolMaxConnections()
+	}
+	return poolSize
+}
+
 func isInvalidCredentialsError(err error) bool {
 	err = errors.Unwrap(err)
 	if err == nil {

--- a/collector/connect_godror_test.go
+++ b/collector/connect_godror_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+//go:build !goora
+
+package collector
+
+import "testing"
+
+func TestEffectiveSQLPoolLimitsUseSQLSettingsForGodror(t *testing.T) {
+	maxOpenConns := 10
+	maxIdleConns := 6
+	poolMaxConnections := 4
+	poolMinConnections := 2
+	config := DatabaseConfig{ConnectConfig: ConnectConfig{
+		MaxOpenConns:       &maxOpenConns,
+		MaxIdleConns:       &maxIdleConns,
+		PoolMaxConnections: &poolMaxConnections,
+		PoolMinConnections: &poolMinConnections,
+	}}
+
+	gotMaxOpenConns, gotMaxIdleConns := effectiveSQLPoolLimits(config)
+	if gotMaxOpenConns != maxOpenConns {
+		t.Fatalf("expected maxOpenConns to set max open connections, got %d", gotMaxOpenConns)
+	}
+	if gotMaxIdleConns != maxIdleConns {
+		t.Fatalf("expected maxIdleConns to set max idle connections, got %d", gotMaxIdleConns)
+	}
+}
+
+func TestWarmupConnectionPoolSizePreservesGodrorPoolFallback(t *testing.T) {
+	maxOpenConns := 0
+	poolMaxConnections := 4
+	config := DatabaseConfig{ConnectConfig: ConnectConfig{
+		MaxOpenConns:       &maxOpenConns,
+		PoolMaxConnections: &poolMaxConnections,
+	}}
+
+	if got := warmupConnectionPoolSize(config); got != poolMaxConnections {
+		t.Fatalf("expected warmup to keep existing poolMaxConnections fallback, got %d", got)
+	}
+}

--- a/collector/connect_goora.go
+++ b/collector/connect_goora.go
@@ -59,24 +59,25 @@ func connect(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) (*sql.
 		return nil, err
 	}
 
-	// Configure connection pool (sql.DB handles pooling)
-	setConnectionPool(logger, dbname, dbconfig, db)
 	return db, nil
 }
 
-func setConnectionPool(logger *slog.Logger, dbname string, dbconfig DatabaseConfig, db *sql.DB) {
+func effectiveSQLPoolLimits(dbconfig DatabaseConfig) (int, int) {
+	maxOpenConns := dbconfig.GetMaxOpenConns()
 	if dbconfig.GetPoolMaxConnections() > 0 {
-		logger.Debug(fmt.Sprintf("set pool max connections to %d", dbconfig.PoolMaxConnections), "database", dbname)
-		db.SetMaxOpenConns(dbconfig.GetPoolMaxConnections())
-	} else {
-		db.SetMaxOpenConns(dbconfig.GetMaxOpenConns())
+		maxOpenConns = dbconfig.GetPoolMaxConnections()
 	}
+
+	maxIdleConns := dbconfig.GetMaxIdleConns()
 	if dbconfig.GetPoolMinConnections() > 0 {
-		logger.Debug(fmt.Sprintf("set pool min connections to %d", dbconfig.PoolMinConnections), "database", dbname)
-		db.SetMaxIdleConns(dbconfig.GetPoolMinConnections())
-	} else {
-		db.SetMaxIdleConns(dbconfig.GetMaxIdleConns())
+		maxIdleConns = dbconfig.GetPoolMinConnections()
 	}
+	return maxOpenConns, maxIdleConns
+}
+
+func warmupConnectionPoolSize(dbconfig DatabaseConfig) int {
+	maxOpenConns, _ := effectiveSQLPoolLimits(dbconfig)
+	return maxOpenConns
 }
 
 func isInvalidCredentialsError(err error) bool {

--- a/collector/connect_goora_test.go
+++ b/collector/connect_goora_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+//go:build goora
+
+package collector
+
+import "testing"
+
+func TestEffectiveSQLPoolLimitsPreferGooraPoolSettings(t *testing.T) {
+	maxOpenConns := 10
+	maxIdleConns := 6
+	poolMaxConnections := 4
+	poolMinConnections := 2
+	config := DatabaseConfig{ConnectConfig: ConnectConfig{
+		MaxOpenConns:       &maxOpenConns,
+		MaxIdleConns:       &maxIdleConns,
+		PoolMaxConnections: &poolMaxConnections,
+		PoolMinConnections: &poolMinConnections,
+	}}
+
+	gotMaxOpenConns, gotMaxIdleConns := effectiveSQLPoolLimits(config)
+	if gotMaxOpenConns != poolMaxConnections {
+		t.Fatalf("expected poolMaxConnections to set max open connections, got %d", gotMaxOpenConns)
+	}
+	if gotMaxIdleConns != poolMinConnections {
+		t.Fatalf("expected poolMinConnections to set max idle connections, got %d", gotMaxIdleConns)
+	}
+	if got := warmupConnectionPoolSize(config); got != poolMaxConnections {
+		t.Fatalf("expected warmup to use poolMaxConnections, got %d", got)
+	}
+}
+
+func TestEffectiveSQLPoolLimitsFallbackToSQLSettingsForGoora(t *testing.T) {
+	maxOpenConns := 8
+	maxIdleConns := 3
+	config := DatabaseConfig{ConnectConfig: ConnectConfig{
+		MaxOpenConns: &maxOpenConns,
+		MaxIdleConns: &maxIdleConns,
+	}}
+
+	gotMaxOpenConns, gotMaxIdleConns := effectiveSQLPoolLimits(config)
+	if gotMaxOpenConns != maxOpenConns {
+		t.Fatalf("expected maxOpenConns fallback, got %d", gotMaxOpenConns)
+	}
+	if gotMaxIdleConns != maxIdleConns {
+		t.Fatalf("expected maxIdleConns fallback, got %d", gotMaxIdleConns)
+	}
+}
+
+func TestInitDBKeepsGooraPoolMaxConnections(t *testing.T) {
+	maxOpenConns := 10
+	poolMaxConnections := 4
+	config := DatabaseConfig{ConnectConfig: ConnectConfig{
+		MaxOpenConns:       &maxOpenConns,
+		PoolMaxConnections: &poolMaxConnections,
+	}}
+	db := openTestQueryDB(t)
+
+	initdb(testLogger(), "db1", config, db)
+
+	if got := db.Stats().MaxOpenConnections; got != poolMaxConnections {
+		t.Fatalf("expected initdb to keep poolMaxConnections as max open connections, got %d", got)
+	}
+}

--- a/collector/database.go
+++ b/collector/database.go
@@ -112,10 +112,15 @@ func (d *Database) warmupSession(logger *slog.Logger, session *sql.DB) error {
 	}
 
 	var connections []*sql.Conn
-	poolSize := d.Config.GetMaxOpenConns()
-	if poolSize < 1 {
-		poolSize = d.Config.GetPoolMaxConnections()
-	}
+	defer func() {
+		for i, conn := range connections {
+			if err := conn.Close(); err != nil {
+				logger.Debug("Failed to return database connection to pool on warmup", "conn", i+1, "error", err, "database", d.Name)
+			}
+		}
+	}()
+
+	poolSize := warmupConnectionPoolSize(d.Config)
 	if poolSize > 100 { // defensively cap poolsize
 		poolSize = 100
 	}
@@ -143,11 +148,6 @@ func (d *Database) warmupSession(logger *slog.Logger, session *sql.DB) error {
 	}
 
 	logger.Debug("Warmed connection pool", "total", len(connections), "database", d.Name)
-	for i, conn := range connections {
-		if err := conn.Close(); err != nil {
-			logger.Debug("Failed to return database connection to pool on warmup", "conn", i+1, "error", err, "database", d.Name)
-		}
-	}
 	return nil
 }
 
@@ -317,10 +317,7 @@ func isClosedDatabaseError(err error) bool {
 }
 
 func initdb(logger *slog.Logger, dbname string, dbconfig DatabaseConfig, db *sql.DB) {
-	logger.Debug(fmt.Sprintf("set max idle connections to %d", dbconfig.MaxIdleConns), "database", dbname)
-	db.SetMaxIdleConns(dbconfig.GetMaxIdleConns())
-	logger.Debug(fmt.Sprintf("set max open connections to %d", dbconfig.MaxOpenConns), "database", dbname)
-	db.SetMaxOpenConns(dbconfig.GetMaxOpenConns())
+	configureSQLConnectionPool(logger, dbname, dbconfig, db)
 	logger.Debug(fmt.Sprintf("set connection max lifetime to %s", dbconfig.GetConnMaxLifetime()), "database", dbname)
 	db.SetConnMaxLifetime(dbconfig.GetConnMaxLifetime())
 	logger.Debug(fmt.Sprintf("Successfully configured connection to %s", maskDsn(dbconfig.URL)), "database", dbname)
@@ -339,4 +336,12 @@ func initdb(logger *slog.Logger, dbname string, dbconfig DatabaseConfig, db *sql
 		logger.Error("error checking my database role", "error", err, "database", dbname)
 	}
 	logger.Info("Connected as SYSDBA? "+sysdba, "database", dbname)
+}
+
+func configureSQLConnectionPool(logger *slog.Logger, dbname string, dbconfig DatabaseConfig, db *sql.DB) {
+	maxOpenConns, maxIdleConns := effectiveSQLPoolLimits(dbconfig)
+	logger.Debug(fmt.Sprintf("set max idle connections to %d", maxIdleConns), "database", dbname)
+	db.SetMaxIdleConns(maxIdleConns)
+	logger.Debug(fmt.Sprintf("set max open connections to %d", maxOpenConns), "database", dbname)
+	db.SetMaxOpenConns(maxOpenConns)
 }

--- a/collector/database_test.go
+++ b/collector/database_test.go
@@ -35,6 +35,7 @@ type testQueryConnector struct {
 }
 
 var testQueryDriverID atomic.Uint64
+var errWarmupConnectionFailed = errors.New("warmup connection failed")
 
 func (testQueryDriver) Open(name string) (driver.Conn, error) {
 	return testQueryConn{rows: &testQueryRows{}}, nil
@@ -100,6 +101,44 @@ func openTestQueryDBWithRows(t *testing.T, rows driver.Rows) *sql.DB {
 		_ = db.Close()
 	})
 	return db
+}
+
+type partialWarmupFailureConnector struct {
+	successfulConnects int64
+	connectAttempts    atomic.Int64
+}
+
+type partialWarmupFailureConn struct{}
+
+func (c *partialWarmupFailureConnector) Connect(context.Context) (driver.Conn, error) {
+	if c.connectAttempts.Add(1) > c.successfulConnects {
+		return nil, errWarmupConnectionFailed
+	}
+	return partialWarmupFailureConn{}, nil
+}
+
+func (c *partialWarmupFailureConnector) Driver() driver.Driver {
+	return testQueryDriver{}
+}
+
+func (partialWarmupFailureConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (partialWarmupFailureConn) Close() error {
+	return nil
+}
+
+func (partialWarmupFailureConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (partialWarmupFailureConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	return driver.RowsAffected(0), nil
+}
+
+func (partialWarmupFailureConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return &testQueryRows{}, nil
 }
 
 func TestIsValid(t *testing.T) {
@@ -214,6 +253,33 @@ func TestWarmupConnectionPoolWithNilSessionSetsStartupReadyAndBackoff(t *testing
 	}
 	if got := db.getUp(); got != 0 {
 		t.Fatalf("expected database up metric to remain 0, got %v", got)
+	}
+}
+
+func TestWarmupSessionClosesAcquiredConnectionsAfterPartialFailure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	connector := &partialWarmupFailureConnector{successfulConnects: 2}
+	session := sql.OpenDB(connector)
+	t.Cleanup(func() {
+		_ = session.Close()
+	})
+	maxOpenConns := 3
+	db := &Database{
+		Name:          "db1",
+		Config:        DatabaseConfig{ConnectConfig: ConnectConfig{MaxOpenConns: &maxOpenConns}},
+		DatabaseLabel: "database",
+	}
+
+	err := db.warmupSession(logger, session)
+
+	if !errors.Is(err, errWarmupConnectionFailed) {
+		t.Fatalf("expected warmup connection failure, got %v", err)
+	}
+	if got := connector.connectAttempts.Load(); got != 3 {
+		t.Fatalf("expected initdb plus partial warmup to make 3 connection attempts, got %d", got)
+	}
+	if got := session.Stats().InUse; got != 0 {
+		t.Fatalf("expected acquired warmup connections to be returned to the pool, got %d in use", got)
 	}
 }
 

--- a/kubernetes/metrics-exporter-config.yaml
+++ b/kubernetes/metrics-exporter-config.yaml
@@ -55,7 +55,7 @@ metrics:
 
 log:
   # Path of log file
-  destination: /opt/alert.log
+  destination: /log/alert.log
   # Interval of log updates
   interval: 15s
   ## Set disable to 1 to disable logging

--- a/kubernetes/metrics-exporter-deployment.yaml
+++ b/kubernetes/metrics-exporter-deployment.yaml
@@ -18,6 +18,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -61,6 +62,8 @@ spec:
             readOnly: true
           - name: tmp
             mountPath: /tmp
+          - name: alert-log
+            mountPath: /log
           # uncomment and customize the next item if you want to provide custom metrics definitions
           #- name: config-volume
           #  mountPath: /oracle/observability/txeventq-metrics.toml
@@ -83,6 +86,8 @@ spec:
           configMap:
             name: metrics-exporter-config
         - name: tmp
+          emptyDir: {}
+        - name: alert-log
           emptyDir: {}
         # uncomment and customize the next item if you want to provide custom metrics definitions
         #- name: config-volume

--- a/site/docs/releases/changelog.md
+++ b/site/docs/releases/changelog.md
@@ -9,7 +9,10 @@ List of upcoming and historic changes to the exporter.
 
 ### Next, TBD
 
-TBD
+- Fix top-level `listenAddress` config so it is honored as the exporter web listen address when `web.listenAddresses` is not configured.
+- Fix go-ora connection warmup so `poolMaxConnections` and `poolMinConnections` are preserved as the SQL connection-pool limits.
+- Fix the Kubernetes sample alert-log path so it writes to a writable `emptyDir` while keeping `readOnlyRootFilesystem` enabled.
+- Return partially acquired warmup connections to the pool when connection pool warmup fails.
 
 ### 2.4.0, May 22nd, 2026
 


### PR DESCRIPTION
Fix the following issues:
- Fix top-level `listenAddress` config so it is honored as the exporter web listen address when `web.listenAddresses` is not configured.
- Fix go-ora connection warmup so `poolMaxConnections` and `poolMinConnections` are preserved as the SQL connection-pool limits.
- Fix the Kubernetes sample alert-log path so it writes to a writable `emptyDir` while keeping `readOnlyRootFilesystem` enabled.
- Return partially acquired warmup connections to the pool when connection pool warmup fails.