### PR TITLE
refactor OCI Auth to its own package

### DIFF
--- a/collector/config.go
+++ b/collector/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/oracle/oracle-db-appdev-monitoring/azvault"
 	"github.com/oracle/oracle-db-appdev-monitoring/hashivault"
+	"github.com/oracle/oracle-db-appdev-monitoring/oci"
 	"github.com/oracle/oracle-db-appdev-monitoring/ocivault"
 	"github.com/prometheus/exporter-toolkit/web"
 	"go.yaml.in/yaml/v2"
@@ -104,10 +105,10 @@ type VaultConfig struct {
 }
 
 type OCIVault struct {
-	ID             string            `yaml:"id"`
-	Auth           ocivault.AuthMode `yaml:"auth,omitempty"`
-	UsernameSecret string            `yaml:"usernameSecret"`
-	PasswordSecret string            `yaml:"passwordSecret"`
+	ID             string       `yaml:"id"`
+	Auth           oci.AuthMode `yaml:"auth,omitempty"`
+	UsernameSecret string       `yaml:"usernameSecret"`
+	PasswordSecret string       `yaml:"passwordSecret"`
 }
 
 type AZVault struct {
@@ -502,7 +503,7 @@ func (m *MetricsConfiguration) validateOCIVaultAuth() error {
 		if cfg.Vault == nil || cfg.Vault.OCI == nil {
 			continue
 		}
-		if err := ocivault.ValidateAuthMode(cfg.Vault.OCI.Auth); err != nil {
+		if err := oci.ValidateAuthMode(cfg.Vault.OCI.Auth); err != nil {
 			return fmt.Errorf("database %q: %w", name, err)
 		}
 	}

--- a/collector/config_test.go
+++ b/collector/config_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/oracle/oracle-db-appdev-monitoring/ocivault"
+	"github.com/oracle/oracle-db-appdev-monitoring/oci"
 )
 
 func TestConnectConfigGetConnMaxLifetime(t *testing.T) {
@@ -53,7 +53,7 @@ func TestDatabaseConfigGetPasswordReturnsPasswordFileError(t *testing.T) {
 func TestDatabaseConfigPassesOCIVaultAuthMode(t *testing.T) {
 	original := getOCIVaultSecret
 	var calls []string
-	getOCIVaultSecret = func(vaultID, secretName string, authMode ocivault.AuthMode) (string, error) {
+	getOCIVaultSecret = func(vaultID, secretName string, authMode oci.AuthMode) (string, error) {
 		calls = append(calls, fmt.Sprintf("%s/%s/%s", vaultID, secretName, authMode))
 		return "secret-value", nil
 	}
@@ -90,7 +90,7 @@ func TestDatabaseConfigPassesOCIVaultAuthMode(t *testing.T) {
 
 func TestMetricsConfigurationValidateOCIVaultAuth(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	authModes := []ocivault.AuthMode{"", "config_file", "instance_principal", "resource_principal", "workload_identity"}
+	authModes := []oci.AuthMode{"", "config_file", "instance_principal", "resource_principal", "workload_identity"}
 
 	for _, authMode := range authModes {
 		t.Run("valid "+string(authMode), func(t *testing.T) {

--- a/collector/vault_resolution_test.go
+++ b/collector/vault_resolution_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/oracle/oracle-db-appdev-monitoring/ocivault"
+	"github.com/oracle/oracle-db-appdev-monitoring/oci"
 )
 
 func TestWarmupConnectionPoolWithOCIVaultLookupErrorUsesBackoff(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	original := getOCIVaultSecret
-	getOCIVaultSecret = func(vaultID, secretName string, authMode ocivault.AuthMode) (string, error) {
+	getOCIVaultSecret = func(vaultID, secretName string, authMode oci.AuthMode) (string, error) {
 		return "", errors.New("vault unavailable")
 	}
 	t.Cleanup(func() {

--- a/oci/auth.go
+++ b/oci/auth.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+// Package oci contains shared OCI integration helpers.
+package oci
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
+)
+
+// AuthMode identifies the OCI SDK authentication provider to use.
+type AuthMode string
+
+const (
+	AuthModeConfigFile        AuthMode = "config_file"
+	AuthModeInstancePrincipal AuthMode = "instance_principal"
+	AuthModeResourcePrincipal AuthMode = "resource_principal"
+	AuthModeWorkloadIdentity  AuthMode = "workload_identity"
+)
+
+var (
+	defaultConfigProvider = func() (common.ConfigurationProvider, error) {
+		return common.DefaultConfigProvider(), nil
+	}
+	instancePrincipalConfigurationProvider = func() (common.ConfigurationProvider, error) {
+		return auth.InstancePrincipalConfigurationProvider()
+	}
+	resourcePrincipalConfigurationProvider = func() (common.ConfigurationProvider, error) {
+		return auth.ResourcePrincipalConfigurationProvider()
+	}
+	workloadIdentityConfigurationProvider = func() (common.ConfigurationProvider, error) {
+		return auth.OkeWorkloadIdentityConfigurationProvider()
+	}
+)
+
+// AcceptedAuthModes returns the supported OCI authentication mode values.
+func AcceptedAuthModes() []string {
+	return []string{
+		string(AuthModeConfigFile),
+		string(AuthModeInstancePrincipal),
+		string(AuthModeResourcePrincipal),
+		string(AuthModeWorkloadIdentity),
+	}
+}
+
+// ValidateAuthMode verifies that authMode is supported. An empty mode defaults
+// to config_file.
+func ValidateAuthMode(authMode AuthMode) error {
+	switch normalizeAuthMode(authMode) {
+	case AuthModeConfigFile, AuthModeInstancePrincipal, AuthModeResourcePrincipal, AuthModeWorkloadIdentity:
+		return nil
+	default:
+		return fmt.Errorf("unsupported OCI auth mode %q; accepted values are: %s", authMode, strings.Join(AcceptedAuthModes(), ", "))
+	}
+}
+
+// ConfigurationProviderForAuthMode returns the OCI SDK configuration provider
+// selected by authMode. Unsupported runtime values use the config-file
+// provider; callers that accept configuration input should call
+// ValidateAuthMode first.
+func ConfigurationProviderForAuthMode(authMode AuthMode) (common.ConfigurationProvider, error) {
+	switch normalizeAuthMode(authMode) {
+	case AuthModeConfigFile:
+		return defaultConfigProvider()
+	case AuthModeInstancePrincipal:
+		return instancePrincipalConfigurationProvider()
+	case AuthModeResourcePrincipal:
+		return resourcePrincipalConfigurationProvider()
+	case AuthModeWorkloadIdentity:
+		return workloadIdentityConfigurationProvider()
+	default:
+		return defaultConfigProvider()
+	}
+}
+
+func normalizeAuthMode(authMode AuthMode) AuthMode {
+	mode := strings.ToLower(strings.TrimSpace(string(authMode)))
+	if mode == "" {
+		return AuthModeConfigFile
+	}
+	return AuthMode(mode)
+}

--- a/oci/auth_test.go
+++ b/oci/auth_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oci
+
+import (
+	"crypto/rsa"
+	"errors"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+)
+
+type fakeConfigurationProvider struct {
+	name string
+}
+
+func (f fakeConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) { return nil, nil }
+func (f fakeConfigurationProvider) KeyID() (string, error)                  { return f.name, nil }
+func (f fakeConfigurationProvider) TenancyOCID() (string, error)            { return "tenancy", nil }
+func (f fakeConfigurationProvider) UserOCID() (string, error)               { return "user", nil }
+func (f fakeConfigurationProvider) KeyFingerprint() (string, error)         { return "fingerprint", nil }
+func (f fakeConfigurationProvider) Region() (string, error)                 { return "us-ashburn-1", nil }
+func (f fakeConfigurationProvider) AuthType() (common.AuthConfig, error) {
+	return common.AuthConfig{}, nil
+}
+
+func TestConfigurationProviderForAuthModeUsesSelectedFactory(t *testing.T) {
+	originalDefault := defaultConfigProvider
+	originalInstance := instancePrincipalConfigurationProvider
+	originalResource := resourcePrincipalConfigurationProvider
+	originalWorkload := workloadIdentityConfigurationProvider
+	t.Cleanup(func() {
+		defaultConfigProvider = originalDefault
+		instancePrincipalConfigurationProvider = originalInstance
+		resourcePrincipalConfigurationProvider = originalResource
+		workloadIdentityConfigurationProvider = originalWorkload
+	})
+
+	defaultConfigProvider = providerFactoryForTest("config_file")
+	instancePrincipalConfigurationProvider = providerFactoryForTest("instance_principal")
+	resourcePrincipalConfigurationProvider = providerFactoryForTest("resource_principal")
+	workloadIdentityConfigurationProvider = providerFactoryForTest("workload_identity")
+
+	tests := []struct {
+		name     string
+		authMode AuthMode
+		want     string
+	}{
+		{name: "empty defaults to config file", authMode: "", want: "config_file"},
+		{name: "config file", authMode: "config_file", want: "config_file"},
+		{name: "instance principal", authMode: "instance_principal", want: "instance_principal"},
+		{name: "resource principal", authMode: "resource_principal", want: "resource_principal"},
+		{name: "workload identity", authMode: "workload_identity", want: "workload_identity"},
+		{name: "trims and lowercases", authMode: " Instance_Principal ", want: "instance_principal"},
+		{name: "unsupported runtime value falls back to config file", authMode: "api_key", want: "config_file"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := ConfigurationProviderForAuthMode(tt.authMode)
+			if err != nil {
+				t.Fatalf("expected provider for auth mode %q, got %v", tt.authMode, err)
+			}
+			fake, ok := provider.(fakeConfigurationProvider)
+			if !ok {
+				t.Fatalf("expected fake provider, got %T", provider)
+			}
+			if fake.name != tt.want {
+				t.Fatalf("expected provider %q, got %q", tt.want, fake.name)
+			}
+		})
+	}
+}
+
+func TestConfigurationProviderForAuthModeReturnsFactoryError(t *testing.T) {
+	original := instancePrincipalConfigurationProvider
+	t.Cleanup(func() { instancePrincipalConfigurationProvider = original })
+	instancePrincipalConfigurationProvider = func() (common.ConfigurationProvider, error) {
+		return nil, errors.New("provider unavailable")
+	}
+
+	_, err := ConfigurationProviderForAuthMode("instance_principal")
+	if err == nil {
+		t.Fatal("expected provider factory error")
+	}
+	if err.Error() != "provider unavailable" {
+		t.Fatalf("expected provider factory error to be returned, got %v", err)
+	}
+}
+
+func providerFactoryForTest(name string) func() (common.ConfigurationProvider, error) {
+	return func() (common.ConfigurationProvider, error) {
+		return fakeConfigurationProvider{name: name}, nil
+	}
+}

--- a/ocivault/ocivault.go
+++ b/ocivault/ocivault.go
@@ -10,53 +10,11 @@ import (
 	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
-	"github.com/oracle/oci-go-sdk/v65/common/auth"
 	"github.com/oracle/oci-go-sdk/v65/secrets"
+	"github.com/oracle/oracle-db-appdev-monitoring/oci"
 )
 
-type AuthMode string
-
-const (
-	AuthModeConfigFile        AuthMode = "config_file"
-	AuthModeInstancePrincipal AuthMode = "instance_principal"
-	AuthModeResourcePrincipal AuthMode = "resource_principal"
-	AuthModeWorkloadIdentity  AuthMode = "workload_identity"
-)
-
-var (
-	defaultConfigProvider = func() (common.ConfigurationProvider, error) {
-		return common.DefaultConfigProvider(), nil
-	}
-	instancePrincipalConfigurationProvider = func() (common.ConfigurationProvider, error) {
-		return auth.InstancePrincipalConfigurationProvider()
-	}
-	resourcePrincipalConfigurationProvider = func() (common.ConfigurationProvider, error) {
-		return auth.ResourcePrincipalConfigurationProvider()
-	}
-	workloadIdentityConfigurationProvider = func() (common.ConfigurationProvider, error) {
-		return auth.OkeWorkloadIdentityConfigurationProvider()
-	}
-)
-
-func AcceptedAuthModes() []string {
-	return []string{
-		string(AuthModeConfigFile),
-		string(AuthModeInstancePrincipal),
-		string(AuthModeResourcePrincipal),
-		string(AuthModeWorkloadIdentity),
-	}
-}
-
-func ValidateAuthMode(authMode AuthMode) error {
-	switch normalizeAuthMode(authMode) {
-	case AuthModeConfigFile, AuthModeInstancePrincipal, AuthModeResourcePrincipal, AuthModeWorkloadIdentity:
-		return nil
-	default:
-		return fmt.Errorf("unsupported OCI Vault auth mode %q; accepted values are: %s", authMode, strings.Join(AcceptedAuthModes(), ", "))
-	}
-}
-
-func GetVaultSecret(vaultId string, secretName string, authMode AuthMode) (string, error) {
+func GetVaultSecret(vaultId string, secretName string, authMode oci.AuthMode) (string, error) {
 	configProvider, err := configurationProviderForAuthMode(authMode)
 	if err != nil {
 		return "", err
@@ -80,28 +38,9 @@ func GetVaultSecret(vaultId string, secretName string, authMode AuthMode) (strin
 	return strings.TrimRight(rawSecret, "\r\n"), nil // make sure a \r and/or \n didn't make it into the secret
 }
 
-func configurationProviderForAuthMode(authMode AuthMode) (common.ConfigurationProvider, error) {
-	mode := normalizeAuthMode(authMode)
-	switch mode {
-	case AuthModeConfigFile:
-		return defaultConfigProvider()
-	case AuthModeInstancePrincipal:
-		return instancePrincipalConfigurationProvider()
-	case AuthModeResourcePrincipal:
-		return resourcePrincipalConfigurationProvider()
-	case AuthModeWorkloadIdentity:
-		return workloadIdentityConfigurationProvider()
-	default:
-		return defaultConfigProvider()
-	}
-}
-
-func normalizeAuthMode(authMode AuthMode) AuthMode {
-	mode := strings.ToLower(strings.TrimSpace(string(authMode)))
-	if mode == "" {
-		return AuthModeConfigFile
-	}
-	return AuthMode(mode)
+func configurationProviderForAuthMode(authMode oci.AuthMode) (common.ConfigurationProvider, error) {
+	configProvider, err := oci.ConfigurationProviderForAuthMode(authMode)
+	return configProvider, err
 }
 
 func getSecretFromBase64(resp secrets.GetSecretBundleByNameResponse) (string, error) {

--- a/ocivault/ocivault_test.go
+++ b/ocivault/ocivault_test.go
@@ -4,113 +4,13 @@
 package ocivault
 
 import (
-	"crypto/rsa"
 	"encoding/base64"
-	"errors"
 	"strings"
 	"testing"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/secrets"
 )
-
-type fakeConfigurationProvider struct {
-	name string
-}
-
-func (f fakeConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
-	return nil, nil
-}
-
-func (f fakeConfigurationProvider) KeyID() (string, error) {
-	return f.name, nil
-}
-
-func (f fakeConfigurationProvider) TenancyOCID() (string, error) {
-	return "tenancy", nil
-}
-
-func (f fakeConfigurationProvider) UserOCID() (string, error) {
-	return "user", nil
-}
-
-func (f fakeConfigurationProvider) KeyFingerprint() (string, error) {
-	return "fingerprint", nil
-}
-
-func (f fakeConfigurationProvider) Region() (string, error) {
-	return "us-ashburn-1", nil
-}
-
-func (f fakeConfigurationProvider) AuthType() (common.AuthConfig, error) {
-	return common.AuthConfig{}, nil
-}
-
-func TestConfigurationProviderForAuthModeUsesSelectedFactory(t *testing.T) {
-	originalDefault := defaultConfigProvider
-	originalInstance := instancePrincipalConfigurationProvider
-	originalResource := resourcePrincipalConfigurationProvider
-	originalWorkload := workloadIdentityConfigurationProvider
-	t.Cleanup(func() {
-		defaultConfigProvider = originalDefault
-		instancePrincipalConfigurationProvider = originalInstance
-		resourcePrincipalConfigurationProvider = originalResource
-		workloadIdentityConfigurationProvider = originalWorkload
-	})
-
-	defaultConfigProvider = providerFactoryForTest("config_file")
-	instancePrincipalConfigurationProvider = providerFactoryForTest("instance_principal")
-	resourcePrincipalConfigurationProvider = providerFactoryForTest("resource_principal")
-	workloadIdentityConfigurationProvider = providerFactoryForTest("workload_identity")
-
-	tests := []struct {
-		name     string
-		authMode AuthMode
-		want     string
-	}{
-		{name: "empty defaults to config file", authMode: "", want: "config_file"},
-		{name: "config file", authMode: "config_file", want: "config_file"},
-		{name: "instance principal", authMode: "instance_principal", want: "instance_principal"},
-		{name: "resource principal", authMode: "resource_principal", want: "resource_principal"},
-		{name: "workload identity", authMode: "workload_identity", want: "workload_identity"},
-		{name: "trims and lowercases", authMode: " Instance_Principal ", want: "instance_principal"},
-		{name: "unsupported runtime value falls back to config file", authMode: "api_key", want: "config_file"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			provider, err := configurationProviderForAuthMode(tt.authMode)
-			if err != nil {
-				t.Fatalf("expected provider for auth mode %q, got %v", tt.authMode, err)
-			}
-			fake, ok := provider.(fakeConfigurationProvider)
-			if !ok {
-				t.Fatalf("expected fake provider, got %T", provider)
-			}
-			if fake.name != tt.want {
-				t.Fatalf("expected provider %q, got %q", tt.want, fake.name)
-			}
-		})
-	}
-}
-
-func TestConfigurationProviderForAuthModeReturnsFactoryError(t *testing.T) {
-	original := instancePrincipalConfigurationProvider
-	t.Cleanup(func() {
-		instancePrincipalConfigurationProvider = original
-	})
-	instancePrincipalConfigurationProvider = func() (common.ConfigurationProvider, error) {
-		return nil, errors.New("provider unavailable")
-	}
-
-	_, err := configurationProviderForAuthMode("instance_principal")
-	if err == nil {
-		t.Fatal("expected provider factory error")
-	}
-	if err.Error() != "provider unavailable" {
-		t.Fatalf("expected provider factory error to be returned, got %v", err)
-	}
-}
 
 func TestGetSecretFromBase64(t *testing.T) {
 	encoded := base64.StdEncoding.EncodeToString([]byte("tiger\r\n"))
@@ -157,11 +57,5 @@ func TestGetSecretFromBase64RejectsUnsupportedContentType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported OCI Vault secret bundle content type") {
 		t.Fatalf("expected unsupported content type error, got %v", err)
-	}
-}
-
-func providerFactoryForTest(name string) func() (common.ConfigurationProvider, error) {
-	return func() (common.ConfigurationProvider, error) {
-		return fakeConfigurationProvider{name: name}, nil
 	}
 }


### PR DESCRIPTION
Moves the OCI Auth functionality to its own package, separate from OCI Vault