### PR TITLE
Create a passwd entry for the exporter uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,12 @@ ADD ./default-metrics.toml /default-metrics.toml
 RUN mkdir /log && chown 1000:1000 /log
 RUN mkdir /wallet && chown 1000:1000 /wallet
 
+# Give uid 1000 a passwd entry: Oracle Client looks the OS user up during OCIServerAttach and,
+# when getpwuid() fails, double-frees a shared buffer under concurrent connects
+# (SIGABRT "double free or corruption" in dpiConn_create, issue #384).
+RUN echo 'exporter:x:1000:1000:exporter:/:/sbin/nologin' >> /etc/passwd && \
+    echo 'exporter:x:1000:' >> /etc/group
+
 EXPOSE 9161
 
 USER 1000


### PR DESCRIPTION
Fixes #384 (and the earlier #177 / #258 reports of the same signature).

The godror image sets `USER 1000` without creating the user, so `getpwuid()` fails at runtime. Oracle Client resolves the OS user name during `OCIServerAttach` and, when that lookup fails, double-frees a process-shared buffer under concurrent connection attempts. That surfaces as `double free or corruption` / `malloc(): unsorted double linked list corrupted` -> `SIGABRT` inside `dpiConn_create`, i.e. exactly the crash-every-30-minutes pattern from #384 (the default 30m `connMaxLifetime` retires all warmed connections at once and the next scrape recreates them concurrently).

Validation:
1. Run the 2.4.2 image against 2+ databases with default settings; previous-container logs show the allocator abort roughly every 30 minutes.
2. Rebuild with this change (or run the current image as a uid that has a passwd entry, e.g. 65534): the crash is gone. In our reproduction the same binary and uid went from aborting within seconds to 5900+ consecutive connects with zero errors after adding the passwd entry.

Signed-off-by: Gleb Mekhrenin <gleb.mekhrenin@gmail.com>