### PR TITLE
Honor pool* keys: select the godror session pool instead of standalone

### DIFF
--- a/collector/connect_godror.go
+++ b/collector/connect_godror.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, Oracle and/or its affiliates.
+// Copyright (c) 2025, 2026, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 //go:build !goora
@@ -19,14 +19,26 @@ import (
 func connect(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) (*sql.DB, error) {
 	logger.Debug("Launching connection to "+maskDsn(dbconfig.URL), "database", dbname)
 
-	var P godror.ConnectionParams
-	password, err := dbconfig.GetPassword()
+	P, err := connectionParams(logger, dbname, dbconfig)
 	if err != nil {
 		return nil, err
 	}
+	// note that this just configures the connection, it does not actually connect until later
+	// when we call db.Ping()
+	db := sql.OpenDB(godror.NewConnector(P))
+	return db, nil
+}
+
+// connectionParams translates the exporter database config into godror connection parameters.
+func connectionParams(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) (godror.ConnectionParams, error) {
+	var P godror.ConnectionParams
+	password, err := dbconfig.GetPassword()
+	if err != nil {
+		return P, err
+	}
 	username, err := dbconfig.GetUsername()
 	if err != nil {
-		return nil, err
+		return P, err
 	}
 	// If password is not specified, externalAuth will be true, and we'll ignore user input
 	dbconfig.ExternalAuth = password == ""
@@ -35,6 +47,7 @@ func connect(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) (*sql.
 	if dbconfig.ExternalAuth {
 		msg = "Database Password not specified; will attempt to use external authentication (ignoring user input)."
 		dbconfig.Username = ""
+		username = "" // the local copy was fetched before this branch; clear it too
 	}
 	logger.Info(msg, "database", dbname)
 	externalAuth := sql.NullBool{
@@ -58,6 +71,14 @@ func connect(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) (*sql.
 
 	P.PoolParams.WaitTimeout = time.Second * 5
 
+	// godror defaults to standalone connections and then ignores PoolParams; opt into the
+	// ODPI-C session pool whenever any pool* key is present in the config, including
+	// explicit zero values. (Administrative roles such as SYSDBA are always standalone
+	// in godror.)
+	if dbconfig.PoolIncrement != nil || dbconfig.PoolMaxConnections != nil || dbconfig.PoolMinConnections != nil {
+		P.StandaloneConnection = sql.NullBool{Bool: false, Valid: true}
+	}
+
 	// if TNS_ADMIN env var is set, set ConfigDir to that location
 	P.ConfigDir = dbconfig.TNSAdmin
 
@@ -80,10 +101,7 @@ func connect(logger *slog.Logger, dbname string, dbconfig DatabaseConfig) (*sql.
 		P.AdminRole = dsn.NoRole
 	}
 
-	// note that this just configures the connection, it does not actually connect until later
-	// when we call db.Ping()
-	db := sql.OpenDB(godror.NewConnector(P))
-	return db, nil
+	return P, nil
 }
 
 func effectiveSQLPoolLimits(dbconfig DatabaseConfig) (int, int) {
@@ -94,6 +112,11 @@ func warmupConnectionPoolSize(dbconfig DatabaseConfig) int {
 	poolSize := dbconfig.GetMaxOpenConns()
 	if poolSize < 1 {
 		poolSize = dbconfig.GetPoolMaxConnections()
+	}
+	// Warmup holds every acquired connection until the loop ends; the native pool
+	// cannot hand out more than MaxSessions, so cap to avoid WaitTimeout errors.
+	if poolMax := dbconfig.GetPoolMaxConnections(); poolMax > 0 && poolSize > poolMax {
+		poolSize = poolMax
 	}
 	return poolSize
 }

--- a/collector/connect_godror_test.go
+++ b/collector/connect_godror_test.go
@@ -5,7 +5,11 @@
 
 package collector
 
-import "testing"
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
 
 func TestEffectiveSQLPoolLimitsUseSQLSettingsForGodror(t *testing.T) {
 	maxOpenConns := 10
@@ -38,5 +42,99 @@ func TestWarmupConnectionPoolSizePreservesGodrorPoolFallback(t *testing.T) {
 
 	if got := warmupConnectionPoolSize(config); got != poolMaxConnections {
 		t.Fatalf("expected warmup to keep existing poolMaxConnections fallback, got %d", got)
+	}
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestConnectionParamsPoolKeysSelectNativePool(t *testing.T) {
+	poolMin, poolMax, poolInc := 1, 5, 1
+	config := DatabaseConfig{Username: "user", Password: "secret", URL: "db.example:1521/svc", ConnectConfig: ConnectConfig{
+		PoolMinConnections: &poolMin,
+		PoolMaxConnections: &poolMax,
+		PoolIncrement:      &poolInc,
+	}}
+
+	P, err := connectionParams(discardLogger(), "db", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if P.IsStandalone() {
+		t.Fatalf("pool* keys are set but godror would open standalone connections (StandaloneConnection=%+v)", P.StandaloneConnection)
+	}
+	if P.PoolParams.MinSessions != poolMin || P.PoolParams.MaxSessions != poolMax || P.PoolParams.SessionIncrement != poolInc {
+		t.Fatalf("pool params not propagated: %+v", P.PoolParams)
+	}
+}
+
+func TestConnectionParamsWithoutPoolKeysKeepGodrorDefault(t *testing.T) {
+	config := DatabaseConfig{Username: "user", Password: "secret", URL: "db.example:1521/svc"}
+
+	P, err := connectionParams(discardLogger(), "db", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if P.StandaloneConnection.Valid {
+		t.Fatalf("no pool* keys: connection mode must stay at godror default, got %+v", P.StandaloneConnection)
+	}
+}
+
+func TestConnectionParamsAdminRoleStaysStandalone(t *testing.T) {
+	poolMax := 5
+	config := DatabaseConfig{Username: "sys", Password: "secret", URL: "db.example:1521/svc", ConnectConfig: ConnectConfig{
+		Role:               "SYSDBA",
+		PoolMaxConnections: &poolMax,
+	}}
+
+	P, err := connectionParams(discardLogger(), "db", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// godror forces standalone connections for administrative roles.
+	if !P.IsStandalone() {
+		t.Fatalf("SYSDBA must remain standalone in godror, got %+v", P)
+	}
+}
+
+func TestConnectionParamsZeroValuedPoolKeySelectsPool(t *testing.T) {
+	poolMin := 0 // present but zero: still an explicit request for the native pool
+	config := DatabaseConfig{Username: "user", Password: "secret", URL: "db.example:1521/svc", ConnectConfig: ConnectConfig{
+		PoolMinConnections: &poolMin,
+	}}
+
+	P, err := connectionParams(discardLogger(), "db", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if P.IsStandalone() {
+		t.Fatalf("poolMinConnections: 0 is present but the connection stays standalone: %+v", P.StandaloneConnection)
+	}
+}
+
+func TestConnectionParamsExternalAuthClearsUsername(t *testing.T) {
+	config := DatabaseConfig{Username: "ignored", Password: "", URL: "db.example:1521/svc"}
+
+	P, err := connectionParams(discardLogger(), "db", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !P.ExternalAuth.Valid || !P.ExternalAuth.Bool {
+		t.Fatalf("empty password must select external auth, got %+v", P.ExternalAuth)
+	}
+	if P.Username != "" {
+		t.Fatalf("external auth must ignore the configured username, got %q", P.Username)
+	}
+}
+
+func TestWarmupConnectionPoolSizeCappedByPoolMax(t *testing.T) {
+	maxOpenConns := 10
+	poolMax := 4
+	config := DatabaseConfig{ConnectConfig: ConnectConfig{
+		MaxOpenConns:       &maxOpenConns,
+		PoolMaxConnections: &poolMax,
+	}}
+
+	if got := warmupConnectionPoolSize(config); got != poolMax {
+		t.Fatalf("warmup must not exceed the native pool MaxSessions: got %d, want %d", got, poolMax)
 	}
 }


### PR DESCRIPTION
Fixes #590.

`connect()` fills PoolParams from poolMinConnections/poolMaxConnections/poolIncrement but never sets StandaloneConnection, and godror defaults to standalone connections, so the documented native pool mode was never used.

- Set StandaloneConnection=false whenever any pool* key is present in the config, including explicit zero values (administrative roles such as SYSDBA stay standalone by godror design).
- Clear the local username copy on the external-authentication path so the connection parameters really ignore user input, as the log message says.
- Cap the warmup loop at poolMaxConnections: warmup holds every acquired connection until the loop ends and the native pool cannot hand out more than MaxSessions, so a larger maxOpenConns would only run into WaitTimeout.
- Extract connectionParams() so the mapping is unit-testable; the added tests cover mode selection, external auth and warmup sizing.

Validation: `go test ./collector`; with pool* keys set, godror debug logging shows `dpiPool_create`/acquire instead of `standalone params=... pool:<nil>` in connection errors.

Signed-off-by: Gleb Mekhrenin <gleb.mekhrenin@gmail.com>