### PR TITLE
Treat ORA-12541 (no listener) as a temporary connection error

### DIFF
--- a/collector/connect_godror.go
+++ b/collector/connect_godror.go
@@ -120,7 +120,7 @@ func isTemporaryConnectionError(err error) bool {
 		return false
 	}
 	switch oraErr.Code() {
-	case ora01033code, ora03113code, ora03114code, ora12537code:
+	case ora01033code, ora03113code, ora03114code, ora12537code, ora12541code:
 		return true
 	default:
 		return false

--- a/collector/connect_goora.go
+++ b/collector/connect_goora.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, Oracle and/or its affiliates.
+// Copyright (c) 2025, 2026, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 //go:build goora
@@ -102,7 +102,7 @@ func isTemporaryConnectionError(err error) bool {
 		return false
 	}
 	switch oraErr.ErrCode {
-	case ora01033code, ora03113code, ora03114code, ora12537code:
+	case ora01033code, ora03113code, ora03114code, ora12537code, ora12541code:
 		return true
 	default:
 		return false

--- a/collector/database.go
+++ b/collector/database.go
@@ -23,6 +23,7 @@ const (
 	ora03113code = 3113
 	ora03114code = 3114
 	ora12537code = 12537
+	ora12541code = 12541 // TNS:no listener
 )
 
 var errDatabaseSessionNotInitialized = errors.New("database session is not initialized")


### PR DESCRIPTION
Fixes #591.

An unreachable listener escapes the backoff classification, so the exporter attempts a fresh native connection on every scrape. Besides the wasted work this adds constant connection churn, which is the load that amplifies #384. Add ORA-12541 to the temporary-error set in both the godror and go-ora paths.

Validation: point one database block at a closed port; with this change the exporter backs off (connectionBackoff) instead of dialing every scrape.

Signed-off-by: Gleb Mekhrenin <gleb.mekhrenin@gmail.com>