### PR TITLE
Add per-metric scrape duration metric

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -29,6 +29,12 @@ var (
 	exporterName = "exporter"
 )
 
+// Values of the "result" label on oracledb_exporter_last_metric_scrape_duration_seconds.
+const (
+	scrapeResultSuccess = "success"
+	scrapeResultError   = "error"
+)
+
 // ScrapeResult is container structure for error handling
 type ScrapeResult struct {
 	Err         error
@@ -83,6 +89,12 @@ func NewExporter(logger *slog.Logger, m *MetricsConfiguration) *Exporter {
 			Name:      "last_database_scrape_duration_seconds",
 			Help:      "Duration of the last scrape of metrics from an Oracle DB.",
 		}, []string{m.DatabaseLabel()}),
+		metricScrapeDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "last_metric_scrape_duration_seconds",
+			Help:      "Duration of the last scrape of an individual metric from Oracle DB, in seconds.",
+		}, []string{"collector", "metric", m.DatabaseLabel(), "result"}),
 		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: exporterName,
@@ -187,6 +199,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.scrape(ch, &now)
 	ch <- e.duration
 	e.databaseDuration.Collect(ch)
+	e.metricScrapeDuration.Collect(ch)
 	ch <- e.totalScrapes
 	ch <- e.error
 	e.scrapeErrors.Collect(ch)
@@ -269,6 +282,7 @@ func (e *Exporter) scheduledScrape(tick *time.Time) {
 	// report metadata metrics
 	metricCh <- e.duration
 	e.databaseDuration.Collect(metricCh)
+	e.metricScrapeDuration.Collect(metricCh)
 	metricCh <- e.totalScrapes
 	metricCh <- e.error
 	e.scrapeErrors.Collect(metricCh)
@@ -357,23 +371,26 @@ func (e *Exporter) scrapeDatabase(ch chan<- prometheus.Metric, errChan chan<- er
 
 			scrapeStart := time.Now()
 			scrapeError := e.ScrapeMetric(d, ch, metric)
+			elapsed := time.Since(scrapeStart)
 			errChan <- scrapeError
 			if scrapeError != nil {
+				e.observeMetricScrapeDuration(d, metric, scrapeResultError, elapsed)
 				if shouldLogScrapeError(scrapeError, metric.IgnoreZeroResult) {
 					e.logger.Error("Error scraping metric",
 						"Context", metric.Context,
 						"MetricsDesc", fmt.Sprint(metric.MetricsDesc),
-						"duration", time.Since(scrapeStart),
+						"duration", elapsed,
 						"error", scrapeError,
 						"database", d.Name)
 				}
 				e.scrapeErrors.WithLabelValues(metric.Context, d.Name).Inc()
 			} else {
+				e.observeMetricScrapeDuration(d, metric, scrapeResultSuccess, elapsed)
 				d.MetricsCache.SetLastScraped(metric, tick)
 				e.logger.Debug("Successfully scraped metric",
 					"Context", metric.Context,
 					"MetricDesc", fmt.Sprint(metric.MetricsDesc),
-					"duration", time.Since(scrapeStart),
+					"duration", elapsed,
 					"database", d.Name)
 			}
 		}()
@@ -414,6 +431,23 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric, tick *time.Time) {
 	}
 
 	e.afterScrape(begun, totalErrors)
+}
+
+// observeMetricScrapeDuration records how long the last scrape of a single metric took for a
+// database. Only one series exists per metric and database at a time: the series for the opposite
+// result is removed, so the reported duration always describes the most recent scrape attempt.
+// Metrics that were not scraped (for example, because of a custom scrape interval) keep the value
+// recorded by their last actual scrape.
+func (e *Exporter) observeMetricScrapeDuration(d *Database, m *Metric, result string, elapsed time.Duration) {
+	if e.metricScrapeDuration == nil {
+		return
+	}
+	other := scrapeResultSuccess
+	if result == scrapeResultSuccess {
+		other = scrapeResultError
+	}
+	e.metricScrapeDuration.DeleteLabelValues(m.Context, m.ID, d.Name, other)
+	e.metricScrapeDuration.WithLabelValues(m.Context, m.ID, d.Name, result).Set(elapsed.Seconds())
 }
 
 func (e *Exporter) afterScrape(begun time.Time, totalErrors float64) {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -51,6 +51,22 @@ func maskDsn(dsn string) string {
 	return dsn
 }
 
+// newMetricScrapeDurationVec builds the per-metric scrape duration vector, or returns nil when the
+// feature is disabled. A nil vector disables the metric entirely: nothing is recorded, and nothing is
+// reported. The metric is opt-in because it adds one series per metric definition and database, which
+// is significant for deployments monitoring many databases.
+func newMetricScrapeDurationVec(m *MetricsConfiguration) *prometheus.GaugeVec {
+	if !m.PerMetricScrapeDurationEnabled() {
+		return nil
+	}
+	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: exporterName,
+		Name:      "last_metric_scrape_duration_seconds",
+		Help:      "Duration of the last scrape of an individual metric from Oracle DB, in seconds.",
+	}, []string{"collector", "metric", m.DatabaseLabel(), "result"})
+}
+
 // NewExporter creates a new Exporter instance
 func NewExporter(logger *slog.Logger, m *MetricsConfiguration) *Exporter {
 	var databases []*Database
@@ -89,12 +105,7 @@ func NewExporter(logger *slog.Logger, m *MetricsConfiguration) *Exporter {
 			Name:      "last_database_scrape_duration_seconds",
 			Help:      "Duration of the last scrape of metrics from an Oracle DB.",
 		}, []string{m.DatabaseLabel()}),
-		metricScrapeDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: exporterName,
-			Name:      "last_metric_scrape_duration_seconds",
-			Help:      "Duration of the last scrape of an individual metric from Oracle DB, in seconds.",
-		}, []string{"collector", "metric", m.DatabaseLabel(), "result"}),
+		metricScrapeDuration: newMetricScrapeDurationVec(m),
 		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: exporterName,
@@ -199,7 +210,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.scrape(ch, &now)
 	ch <- e.duration
 	e.databaseDuration.Collect(ch)
-	e.metricScrapeDuration.Collect(ch)
+	if e.metricScrapeDuration != nil {
+		e.metricScrapeDuration.Collect(ch)
+	}
 	ch <- e.totalScrapes
 	ch <- e.error
 	e.scrapeErrors.Collect(ch)
@@ -282,7 +295,9 @@ func (e *Exporter) scheduledScrape(tick *time.Time) {
 	// report metadata metrics
 	metricCh <- e.duration
 	e.databaseDuration.Collect(metricCh)
-	e.metricScrapeDuration.Collect(metricCh)
+	if e.metricScrapeDuration != nil {
+		e.metricScrapeDuration.Collect(metricCh)
+	}
 	metricCh <- e.totalScrapes
 	metricCh <- e.error
 	e.scrapeErrors.Collect(metricCh)
@@ -439,6 +454,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric, tick *time.Time) {
 // Metrics that were not scraped (for example, because of a custom scrape interval) keep the value
 // recorded by their last actual scrape.
 func (e *Exporter) observeMetricScrapeDuration(d *Database, m *Metric, result string, elapsed time.Duration) {
+	// The vector is nil when metrics.perMetricScrapeDuration.enabled is false.
 	if e.metricScrapeDuration == nil {
 		return
 	}

--- a/collector/config.go
+++ b/collector/config.go
@@ -130,11 +130,18 @@ type HashiCorpVault struct {
 }
 
 type MetricsFilesConfig struct {
-	DatabaseLabel     string `yaml:"databaseLabel"`
-	Default           string
-	Custom            []string
-	ScrapeInterval    *time.Duration `yaml:"scrapeInterval"`
-	ConnectionBackoff *time.Duration `yaml:"connectionBackoff"`
+	DatabaseLabel           string `yaml:"databaseLabel"`
+	Default                 string
+	Custom                  []string
+	ScrapeInterval          *time.Duration                `yaml:"scrapeInterval"`
+	ConnectionBackoff       *time.Duration                `yaml:"connectionBackoff"`
+	PerMetricScrapeDuration PerMetricScrapeDurationConfig `yaml:"perMetricScrapeDuration"`
+}
+
+// PerMetricScrapeDurationConfig configures the optional per-metric scrape duration metric.
+// The metric is disabled by default, as it adds one series per metric definition and database.
+type PerMetricScrapeDurationConfig struct {
+	Enabled *bool `yaml:"enabled"`
 }
 
 type LoggingConfig struct {
@@ -152,6 +159,15 @@ func (m *MetricsConfiguration) DatabaseLabel() string {
 		return "database"
 	}
 	return m.Metrics.DatabaseLabel
+}
+
+// PerMetricScrapeDurationEnabled reports whether the exporter records how long the scrape of each
+// individual metric took. Disabled by default, as it adds one series per metric definition and database.
+func (m *MetricsConfiguration) PerMetricScrapeDurationEnabled() bool {
+	if m.Metrics.PerMetricScrapeDuration.Enabled == nil {
+		return false
+	}
+	return *m.Metrics.PerMetricScrapeDuration.Enabled
 }
 
 func (m *MetricsConfiguration) LogDestination() string {
@@ -440,6 +456,10 @@ func (m *MetricsConfiguration) mergeLoggingConfig() {
 func (m *MetricsConfiguration) mergeMetricsConfig() {
 	if len(m.Metrics.Default) == 0 {
 		m.Metrics.Default = "default-metrics.toml"
+	}
+	if m.Metrics.PerMetricScrapeDuration.Enabled == nil {
+		perMetricScrapeDuration := false
+		m.Metrics.PerMetricScrapeDuration.Enabled = &perMetricScrapeDuration
 	}
 }
 

--- a/collector/config_test.go
+++ b/collector/config_test.go
@@ -150,6 +150,79 @@ databases:
 	if got := *cfg.Web.ListenAddresses; len(got) != 1 || got[0] != ":9161" {
 		t.Fatalf("expected default web listen address, got %#v", got)
 	}
+	if cfg.PerMetricScrapeDurationEnabled() {
+		t.Fatal("expected the per-metric scrape duration metric to be disabled by default")
+	}
+}
+
+func TestLoadMetricsConfigurationReadsPerMetricScrapeDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		metrics string
+		want    bool
+	}{
+		{
+			name: "enabled",
+			metrics: `
+metrics:
+  perMetricScrapeDuration:
+    enabled: true
+`,
+			want: true,
+		},
+		{
+			name: "explicitly disabled",
+			metrics: `
+metrics:
+  perMetricScrapeDuration:
+    enabled: false
+`,
+			want: false,
+		},
+		{
+			name:    "not configured",
+			metrics: "",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := writeExporterConfig(t, `
+databases:
+  default:
+    username: scott
+    password: tiger
+    url: localhost:1521/freepdb1
+`+tt.metrics)
+
+			cfg, err := LoadMetricsConfiguration(testLogger(), &Config{ConfigFile: configPath})
+			if err != nil {
+				t.Fatalf("expected config to load, got %v", err)
+			}
+			if got := cfg.PerMetricScrapeDurationEnabled(); got != tt.want {
+				t.Fatalf("expected PerMetricScrapeDurationEnabled() to be %t, got %t", tt.want, got)
+			}
+		})
+	}
+}
+
+// The config is parsed with yaml.UnmarshalStrict, so a misspelled key must not be silently ignored.
+func TestLoadMetricsConfigurationRejectsUnknownMetricsKey(t *testing.T) {
+	configPath := writeExporterConfig(t, `
+databases:
+  default:
+    username: scott
+    password: tiger
+    url: localhost:1521/freepdb1
+metrics:
+  perMetricScrapeDurations:
+    enabled: true
+`)
+
+	if _, err := LoadMetricsConfiguration(testLogger(), &Config{ConfigFile: configPath}); err == nil {
+		t.Fatal("expected a misspelled metrics key to be rejected")
+	}
 }
 
 func TestLoadMetricsConfigurationMapsLegacyListenAddressToWebConfig(t *testing.T) {

--- a/collector/data_loader.go
+++ b/collector/data_loader.go
@@ -23,6 +23,7 @@ func (e *Exporter) reloadMetrics() bool {
 	e.refreshCustomMetricsHashes()
 	e.initCache()
 	// Metric definitions that no longer exist must not keep reporting the duration of their last scrape.
+	// The vector is nil when metrics.perMetricScrapeDuration.enabled is false.
 	if e.metricScrapeDuration != nil {
 		e.metricScrapeDuration.Reset()
 	}

--- a/collector/data_loader.go
+++ b/collector/data_loader.go
@@ -22,6 +22,10 @@ func (e *Exporter) reloadMetrics() bool {
 	e.metricsToScrape = metricsToScrape
 	e.refreshCustomMetricsHashes()
 	e.initCache()
+	// Metric definitions that no longer exist must not keep reporting the duration of their last scrape.
+	if e.metricScrapeDuration != nil {
+		e.metricScrapeDuration.Reset()
+	}
 	return true
 }
 

--- a/collector/database_test.go
+++ b/collector/database_test.go
@@ -477,6 +477,12 @@ func newTestScheduledExporter(t *testing.T, scrapeInterval time.Duration) (*Expo
 			Name:      "last_database_scrape_duration_seconds",
 			Help:      "test",
 		}, []string{"database"}),
+		metricScrapeDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "last_metric_scrape_duration_seconds",
+			Help:      "test",
+		}, []string{"collector", "metric", "database", "result"}),
 		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: exporterName,

--- a/collector/metric_scrape_duration_test.go
+++ b/collector/metric_scrape_duration_test.go
@@ -97,7 +97,14 @@ context = "custom_instances"
 metricsdesc = { value = "Custom instances." }
 request = "select 1 as value from dual"
 `)
-	exporter := newTestExporterWithCustomMetrics(path)
+	// The shared helper leaves the feature disabled, so build an exporter that enables it.
+	enabled := true
+	exporter := NewExporter(slog.New(slog.NewTextHandler(io.Discard, nil)), &MetricsConfiguration{
+		Metrics: MetricsFilesConfig{
+			Custom:                  []string{path},
+			PerMetricScrapeDuration: PerMetricScrapeDurationConfig{Enabled: &enabled},
+		},
+	})
 	database := &Database{Name: "db1", DatabaseLabel: "database"}
 	removed := newTestDurationMetric("")
 	exporter.observeMetricScrapeDuration(database, removed, scrapeResultSuccess, time.Second)
@@ -130,35 +137,64 @@ func TestCollectEmitsMetricScrapeDuration(t *testing.T) {
 	t.Run("on demand scrapes", func(t *testing.T) {
 		metric := newTestDurationMetric("")
 		exporter, database := newTestDurationExporter(t, openTestQueryDBWithRows(t, nil), metric)
-		exporter.mu = &sync.Mutex{}
-		exporter.totalScrapes = prometheus.NewCounter(prometheus.CounterOpts{Name: "test_scrapes_total", Help: "test"})
-		exporter.duration = prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_duration_seconds", Help: "test"})
-		exporter.error = prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_error", Help: "test"})
-		exporter.databases = []*Database{database}
 
-		var descs []string
-		ch := make(chan prometheus.Metric)
-		done := make(chan struct{})
-		go func() {
-			for m := range ch {
-				descs = append(descs, m.Desc().String())
-			}
-			close(done)
-		}()
-		exporter.Collect(ch)
-		close(ch)
-		<-done
+		descs := collectExporterMetrics(t, exporter, database)
 
-		found := false
-		for _, desc := range descs {
-			if strings.Contains(desc, `fqName: "`+metricScrapeDurationName+`"`) {
-				found = true
-			}
-		}
-		if !found {
+		if !containsMetric(descs, metricScrapeDurationName) {
 			t.Fatalf("expected %s in the on-demand collect results, got %v", metricScrapeDurationName, descs)
 		}
 	})
+}
+
+// The metric is opt-in: it adds one series per metric definition and database, which matters for
+// deployments monitoring many databases.
+func TestPerMetricScrapeDurationIsOptIn(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled *bool
+		want    bool
+	}{
+		{name: "absent from config", enabled: nil, want: false},
+		{name: "explicitly disabled", enabled: boolPtr(false), want: false},
+		{name: "explicitly enabled", enabled: boolPtr(true), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &MetricsConfiguration{
+				Metrics: MetricsFilesConfig{
+					PerMetricScrapeDuration: PerMetricScrapeDurationConfig{Enabled: tt.enabled},
+				},
+			}
+			if got := config.PerMetricScrapeDurationEnabled(); got != tt.want {
+				t.Fatalf("expected PerMetricScrapeDurationEnabled() to be %t, got %t", tt.want, got)
+			}
+
+			exporter := NewExporter(slog.New(slog.NewTextHandler(io.Discard, nil)), config)
+			if got := exporter.metricScrapeDuration != nil; got != tt.want {
+				t.Fatalf("expected the duration vector to be created: %t, got %t", tt.want, got)
+			}
+		})
+	}
+}
+
+// A disabled exporter must neither report the metric nor panic on the nil vector.
+func TestScrapeDatabaseSkipsDurationWhenDisabled(t *testing.T) {
+	metric := newTestDurationMetric("")
+	exporter, database := newTestDurationExporter(t, openTestQueryDBWithRows(t, nil), metric)
+	exporter.metricScrapeDuration = nil
+
+	runScrapeDatabase(t, exporter, database)
+
+	descs := collectExporterMetrics(t, exporter, database)
+
+	if containsMetric(descs, metricScrapeDurationName) {
+		t.Fatalf("did not expect %s while the feature is disabled, got %v", metricScrapeDurationName, descs)
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 func newTestDurationMetric(scrapeInterval string) *Metric {
@@ -227,6 +263,41 @@ func runScrapeDatabase(t *testing.T, exporter *Exporter, database *Database) {
 	}
 	for range errChan {
 	}
+}
+
+// collectExporterMetrics fills in the exporter fields Collect needs, runs a full on-demand
+// collection, and returns the descriptor of every metric that was emitted.
+func collectExporterMetrics(t *testing.T, exporter *Exporter, database *Database) []string {
+	t.Helper()
+
+	exporter.mu = &sync.Mutex{}
+	exporter.totalScrapes = prometheus.NewCounter(prometheus.CounterOpts{Name: "test_scrapes_total", Help: "test"})
+	exporter.duration = prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_duration_seconds", Help: "test"})
+	exporter.error = prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_error", Help: "test"})
+	exporter.databases = []*Database{database}
+
+	var descs []string
+	ch := make(chan prometheus.Metric)
+	done := make(chan struct{})
+	go func() {
+		for m := range ch {
+			descs = append(descs, m.Desc().String())
+		}
+		close(done)
+	}()
+	exporter.Collect(ch)
+	close(ch)
+	<-done
+	return descs
+}
+
+func containsMetric(descs []string, fqName string) bool {
+	for _, desc := range descs {
+		if strings.Contains(desc, `fqName: "`+fqName+`"`) {
+			return true
+		}
+	}
+	return false
 }
 
 // gaugeSeries returns the current values of a GaugeVec, keyed by a stable rendering of its labels.

--- a/collector/metric_scrape_duration_test.go
+++ b/collector/metric_scrape_duration_test.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package collector
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const metricScrapeDurationName = "oracledb_exporter_last_metric_scrape_duration_seconds"
+
+func TestScrapeDatabaseRecordsMetricScrapeDuration(t *testing.T) {
+	tests := []struct {
+		name       string
+		rows       driver.Rows
+		wantResult string
+	}{
+		{name: "successful scrape", rows: nil, wantResult: scrapeResultSuccess},
+		{name: "failed scrape", rows: &testRowsWithIterationError{}, wantResult: scrapeResultError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := newTestDurationMetric("")
+			exporter, database := newTestDurationExporter(t, openTestQueryDBWithRows(t, tt.rows), metric)
+
+			runScrapeDatabase(t, exporter, database)
+
+			series := gaugeSeries(t, exporter.metricScrapeDuration)
+			if len(series) != 1 {
+				t.Fatalf("expected exactly one duration series, got %d: %v", len(series), series)
+			}
+			wantKey := durationKey(metric.Context, metric.ID, database.Name, tt.wantResult)
+			value, ok := series[wantKey]
+			if !ok {
+				t.Fatalf("expected duration series %q, got %v", wantKey, series)
+			}
+			if value < 0 {
+				t.Fatalf("expected a non-negative duration for %q, got %v", wantKey, value)
+			}
+		})
+	}
+}
+
+func TestScrapeDatabaseReplacesPreviousScrapeResult(t *testing.T) {
+	metric := newTestDurationMetric("")
+	exporter, database := newTestDurationExporter(t, openTestQueryDBWithRows(t, nil), metric)
+
+	// Seed the opposite result, as a previously failing scrape would.
+	exporter.observeMetricScrapeDuration(database, metric, scrapeResultError, 5*time.Second)
+
+	runScrapeDatabase(t, exporter, database)
+
+	series := gaugeSeries(t, exporter.metricScrapeDuration)
+	if len(series) != 1 {
+		t.Fatalf("expected the stale error series to be removed, got %d series: %v", len(series), series)
+	}
+	if _, ok := series[durationKey(metric.Context, metric.ID, database.Name, scrapeResultSuccess)]; !ok {
+		t.Fatalf("expected only a success series after a successful scrape, got %v", series)
+	}
+}
+
+func TestScrapeDatabaseKeepsDurationForSkippedMetric(t *testing.T) {
+	metric := newTestDurationMetric("1h")
+	exporter, database := newTestDurationExporter(t, openTestQueryDBWithRows(t, nil), metric)
+
+	const seeded = 1.5
+	exporter.observeMetricScrapeDuration(database, metric, scrapeResultSuccess, 1500*time.Millisecond)
+	// The metric was just scraped, so its custom scrape interval means it is served from the cache.
+	tick := time.Now()
+	database.MetricsCache.SetLastScraped(metric, &tick)
+
+	runScrapeDatabase(t, exporter, database)
+
+	series := gaugeSeries(t, exporter.metricScrapeDuration)
+	key := durationKey(metric.Context, metric.ID, database.Name, scrapeResultSuccess)
+	if got := series[key]; got != seeded {
+		t.Fatalf("expected the skipped metric to keep its previous duration %v, got %v", seeded, got)
+	}
+}
+
+func TestReloadMetricsResetsMetricScrapeDuration(t *testing.T) {
+	path := writeCustomMetricsFixture(t, `
+[[metric]]
+context = "custom_instances"
+metricsdesc = { value = "Custom instances." }
+request = "select 1 as value from dual"
+`)
+	exporter := newTestExporterWithCustomMetrics(path)
+	database := &Database{Name: "db1", DatabaseLabel: "database"}
+	removed := newTestDurationMetric("")
+	exporter.observeMetricScrapeDuration(database, removed, scrapeResultSuccess, time.Second)
+
+	if !exporter.reloadMetrics() {
+		t.Fatal("expected metrics reload to succeed")
+	}
+
+	if series := gaugeSeries(t, exporter.metricScrapeDuration); len(series) != 0 {
+		t.Fatalf("expected duration series to be cleared on reload, got %v", series)
+	}
+}
+
+// The exporter emits its built-in metrics from two separate code paths, and both must include
+// the per-metric scrape duration.
+func TestCollectEmitsMetricScrapeDuration(t *testing.T) {
+	t.Run("scheduled scrapes", func(t *testing.T) {
+		exporter, database := newTestScheduledExporter(t, time.Hour)
+		database.startupReady.Store(true)
+		database.setUp(1)
+
+		tick := time.Now()
+		exporter.scheduledScrape(&tick)
+
+		if !hasScheduledMetric(exporter, metricScrapeDurationName) {
+			t.Fatalf("expected %s in the scheduled scrape results", metricScrapeDurationName)
+		}
+	})
+
+	t.Run("on demand scrapes", func(t *testing.T) {
+		metric := newTestDurationMetric("")
+		exporter, database := newTestDurationExporter(t, openTestQueryDBWithRows(t, nil), metric)
+		exporter.mu = &sync.Mutex{}
+		exporter.totalScrapes = prometheus.NewCounter(prometheus.CounterOpts{Name: "test_scrapes_total", Help: "test"})
+		exporter.duration = prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_duration_seconds", Help: "test"})
+		exporter.error = prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_error", Help: "test"})
+		exporter.databases = []*Database{database}
+
+		var descs []string
+		ch := make(chan prometheus.Metric)
+		done := make(chan struct{})
+		go func() {
+			for m := range ch {
+				descs = append(descs, m.Desc().String())
+			}
+			close(done)
+		}()
+		exporter.Collect(ch)
+		close(ch)
+		<-done
+
+		found := false
+		for _, desc := range descs {
+			if strings.Contains(desc, `fqName: "`+metricScrapeDurationName+`"`) {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected %s in the on-demand collect results, got %v", metricScrapeDurationName, descs)
+		}
+	})
+}
+
+func newTestDurationMetric(scrapeInterval string) *Metric {
+	metric := &Metric{
+		Context:        "test",
+		MetricsDesc:    map[string]string{"value": "Test metric."},
+		MetricsType:    map[string]string{"value": "gauge"},
+		Request:        "select 1 as value from dual",
+		ScrapeInterval: scrapeInterval,
+	}
+	metric.normalizeIdentifiers()
+	return metric
+}
+
+func newTestDurationExporter(t *testing.T, session *sql.DB, metric *Metric) (*Exporter, *Database) {
+	t.Helper()
+
+	metricsToScrape := map[string]*Metric{metric.ID: metric}
+	database := &Database{
+		Name:          "db1",
+		Session:       session,
+		DatabaseLabel: "database",
+	}
+	database.startupReady.Store(true)
+	database.initCache(metricsToScrape)
+
+	exporter := &Exporter{
+		logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MetricsConfiguration: &MetricsConfiguration{},
+		metricsToScrape:      metricsToScrape,
+		databaseDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "last_database_scrape_duration_seconds",
+			Help:      "test",
+		}, []string{"database"}),
+		metricScrapeDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "last_metric_scrape_duration_seconds",
+			Help:      "test",
+		}, []string{"collector", "metric", "database", "result"}),
+		scrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: exporterName,
+			Name:      "scrape_errors_total",
+			Help:      "test",
+		}, []string{"collector", "database"}),
+	}
+	return exporter, database
+}
+
+// runScrapeDatabase performs a single database scrape and waits for every per-metric goroutine to finish.
+func runScrapeDatabase(t *testing.T, exporter *Exporter, database *Database) {
+	t.Helper()
+
+	metricCh := make(chan prometheus.Metric, len(exporter.metricsToScrape)+1)
+	errChan := make(chan error, len(exporter.metricsToScrape)+1)
+	now := time.Now()
+
+	// scrapeDatabase waits for its metric goroutines before returning.
+	exporter.scrapeDatabase(metricCh, errChan, database, &now)
+	close(metricCh)
+	close(errChan)
+	for range metricCh {
+	}
+	for range errChan {
+	}
+}
+
+// gaugeSeries returns the current values of a GaugeVec, keyed by a stable rendering of its labels.
+func gaugeSeries(t *testing.T, vec *prometheus.GaugeVec) map[string]float64 {
+	t.Helper()
+
+	registry := prometheus.NewPedanticRegistry()
+	registry.MustRegister(vec)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	series := map[string]float64{}
+	for _, family := range families {
+		for _, m := range family.GetMetric() {
+			pairs := make([]string, 0, len(m.GetLabel()))
+			for _, label := range m.GetLabel() {
+				pairs = append(pairs, label.GetName()+"="+label.GetValue())
+			}
+			sort.Strings(pairs)
+			series[fmt.Sprintf("%s{%s}", family.GetName(), strings.Join(pairs, ","))] = m.GetGauge().GetValue()
+		}
+	}
+	return series
+}
+
+func durationKey(collector, metricID, database, result string) string {
+	pairs := []string{
+		"collector=" + collector,
+		"database=" + database,
+		"metric=" + metricID,
+		"result=" + result,
+	}
+	sort.Strings(pairs)
+	return fmt.Sprintf("%s{%s}", metricScrapeDurationName, strings.Join(pairs, ","))
+}

--- a/collector/types.go
+++ b/collector/types.go
@@ -20,13 +20,15 @@ type Exporter struct {
 	customMetricsHashes map[string][]byte
 	duration, error     prometheus.Gauge
 	databaseDuration    *prometheus.GaugeVec
-	totalScrapes        prometheus.Counter
-	scrapeErrors        *prometheus.CounterVec
-	scrapeResults       []prometheus.Metric
-	scrapeRequests      chan struct{}
-	databases           []*Database
-	logger              *slog.Logger
-	allConstLabels      []string
+	// metricScrapeDuration tracks how long the last scrape of each individual metric took, per database.
+	metricScrapeDuration *prometheus.GaugeVec
+	totalScrapes         prometheus.Counter
+	scrapeErrors         *prometheus.CounterVec
+	scrapeResults        []prometheus.Metric
+	scrapeRequests       chan struct{}
+	databases            []*Database
+	logger               *slog.Logger
+	allConstLabels       []string
 }
 
 type Database struct {

--- a/collector/types.go
+++ b/collector/types.go
@@ -21,6 +21,7 @@ type Exporter struct {
 	duration, error     prometheus.Gauge
 	databaseDuration    *prometheus.GaugeVec
 	// metricScrapeDuration tracks how long the last scrape of each individual metric took, per database.
+	// It is nil unless metrics.perMetricScrapeDuration.enabled is set; a nil vector disables the metric.
 	metricScrapeDuration *prometheus.GaugeVec
 	totalScrapes         prometheus.Counter
 	scrapeErrors         *prometheus.CounterVec

--- a/example-config-multi-database.yaml
+++ b/example-config-multi-database.yaml
@@ -100,6 +100,11 @@ databases:
 metrics:
   ## How often to scrape metrics. If not provided, metrics will be scraped on request.
   # scrapeInterval: 15s
+  ## Report how long the last scrape of each individual metric took.
+  ## Disabled by default. This adds one series per metric definition and database, so the
+  ## series count grows with the number of databases configured above.
+  # perMetricScrapeDuration:
+  #   enabled: false
   ## Path to default metrics file.
   default: default-metrics.toml
   ## Paths to any custom metrics files

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -47,6 +47,10 @@ databases:
 metrics:
   ## How often to scrape metrics. If not provided, metrics will be scraped on request.
   # scrapeInterval: 15s
+  ## Report how long the last scrape of each individual metric took.
+  ## Disabled by default; adds one series per metric definition and database.
+  # perMetricScrapeDuration:
+  #   enabled: false
   ## Path to default metrics file.
   default: default-metrics.toml
   ## Paths to any custom metrics files

--- a/site/docs/configuration/config-file.md
+++ b/site/docs/configuration/config-file.md
@@ -78,6 +78,10 @@ metrics:
   ## How long to wait before attempting to reconnect to an invalid database (login or locked user).
   ## Defaults to 5 minutes.
   # connectionBackoff: 5m
+  ## Report how long the last scrape of each individual metric took.
+  ## Disabled by default; adds one series per metric definition and database.
+  # perMetricScrapeDuration:
+  #   enabled: false
   ## Path to default metrics file.
   default: default-metrics.toml
   ## Paths to any custom metrics files

--- a/site/docs/getting-started/default-metrics.md
+++ b/site/docs/getting-started/default-metrics.md
@@ -9,6 +9,14 @@ The exporter includes [default metrics](https://github.com/oracle/oracle-db-appd
 
 You can find the exporter's metric schema in the [Custom Metrics configuration](../configuration/custom-metrics.md#metric-schema).
 
+The exporter also reports how long the last scrape of each individual metric took, as
+`oracledb_exporter_last_metric_scrape_duration_seconds`. One series is reported per metric definition and
+database, labelled with the metric's `context` (as `collector`), its unique identifier (as `metric`), and
+whether that scrape succeeded (as `result`). Note that a single metric definition may produce several
+Prometheus metrics -- the `activity` metric below is scraped once and yields four -- so the duration is
+reported per definition, not per resulting metric. Use it to find which query is responsible when
+`oracledb_exporter_last_database_scrape_duration_seconds` grows.
+
 The following metrics are included by default. The values given are a sample for a single database, "db1":
 
 ```bash
@@ -38,6 +46,11 @@ oracledb_dbtype{database="db1"} 3
 # HELP oracledb_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which oracledb_exporter was built, and the goos and goarch for the build.
 # TYPE oracledb_exporter_build_info gauge
 oracledb_exporter_build_info{branch="",goarch="arm64",goos="darwin",goversion="go1.24.5",revision="unknown",tags="unknown",version=""} 1
+# HELP oracledb_exporter_last_metric_scrape_duration_seconds Duration of the last scrape of an individual metric from Oracle DB, in seconds.
+# TYPE oracledb_exporter_last_metric_scrape_duration_seconds gauge
+oracledb_exporter_last_metric_scrape_duration_seconds{collector="activity",database="db1",metric="activity_value",result="success"} 0.001687
+oracledb_exporter_last_metric_scrape_duration_seconds{collector="sessions",database="db1",metric="sessions_value",result="success"} 0.002214
+oracledb_exporter_last_metric_scrape_duration_seconds{collector="top_sql",database="db1",metric="top_sql_elapsed",result="success"} 0.041903
 # HELP oracledb_exporter_last_scrape_duration_seconds Duration of the last scrape of metrics from Oracle DB.
 # TYPE oracledb_exporter_last_scrape_duration_seconds gauge
 oracledb_exporter_last_scrape_duration_seconds 0.05714725

--- a/site/docs/getting-started/default-metrics.md
+++ b/site/docs/getting-started/default-metrics.md
@@ -9,14 +9,6 @@ The exporter includes [default metrics](https://github.com/oracle/oracle-db-appd
 
 You can find the exporter's metric schema in the [Custom Metrics configuration](../configuration/custom-metrics.md#metric-schema).
 
-The exporter also reports how long the last scrape of each individual metric took, as
-`oracledb_exporter_last_metric_scrape_duration_seconds`. One series is reported per metric definition and
-database, labelled with the metric's `context` (as `collector`), its unique identifier (as `metric`), and
-whether that scrape succeeded (as `result`). Note that a single metric definition may produce several
-Prometheus metrics -- the `activity` metric below is scraped once and yields four -- so the duration is
-reported per definition, not per resulting metric. Use it to find which query is responsible when
-`oracledb_exporter_last_database_scrape_duration_seconds` grows.
-
 The following metrics are included by default. The values given are a sample for a single database, "db1":
 
 ```bash
@@ -46,11 +38,6 @@ oracledb_dbtype{database="db1"} 3
 # HELP oracledb_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which oracledb_exporter was built, and the goos and goarch for the build.
 # TYPE oracledb_exporter_build_info gauge
 oracledb_exporter_build_info{branch="",goarch="arm64",goos="darwin",goversion="go1.24.5",revision="unknown",tags="unknown",version=""} 1
-# HELP oracledb_exporter_last_metric_scrape_duration_seconds Duration of the last scrape of an individual metric from Oracle DB, in seconds.
-# TYPE oracledb_exporter_last_metric_scrape_duration_seconds gauge
-oracledb_exporter_last_metric_scrape_duration_seconds{collector="activity",database="db1",metric="activity_value",result="success"} 0.001687
-oracledb_exporter_last_metric_scrape_duration_seconds{collector="sessions",database="db1",metric="sessions_value",result="success"} 0.002214
-oracledb_exporter_last_metric_scrape_duration_seconds{collector="top_sql",database="db1",metric="top_sql_elapsed",result="success"} 0.041903
 # HELP oracledb_exporter_last_scrape_duration_seconds Duration of the last scrape of metrics from Oracle DB.
 # TYPE oracledb_exporter_last_scrape_duration_seconds gauge
 oracledb_exporter_last_scrape_duration_seconds 0.05714725
@@ -147,6 +134,64 @@ oracledb_wait_time_system_io{database="db1"} 0.13
 # TYPE oracledb_wait_time_user_io counter
 oracledb_wait_time_user_io{database="db1"} 12.38
 ```
+
+## Per-Metric Scrape Duration
+
+The exporter can report how long the last scrape of each individual metric took, as
+`oracledb_exporter_last_metric_scrape_duration_seconds`. Use it to find which query is responsible when
+`oracledb_exporter_last_database_scrape_duration_seconds` grows, without having to enable debug logging.
+
+This metric is **disabled by default**. Enable it in your exporter configuration file:
+
+| Parameter                                | Description                                                          | Default |
+|------------------------------------------|----------------------------------------------------------------------|---------|
+| metrics.perMetricScrapeDuration.enabled  | When `true`, report the scrape duration of each individual metric.   | `false` |
+
+```yaml
+metrics:
+  perMetricScrapeDuration:
+    enabled: true
+```
+
+When enabled, the exporter reports one series per metric definition and database:
+
+```bash
+# HELP oracledb_exporter_last_metric_scrape_duration_seconds Duration of the last scrape of an individual metric from Oracle DB, in seconds.
+# TYPE oracledb_exporter_last_metric_scrape_duration_seconds gauge
+oracledb_exporter_last_metric_scrape_duration_seconds{collector="activity",database="db1",metric="activity_value",result="success"} 0.001687
+oracledb_exporter_last_metric_scrape_duration_seconds{collector="sessions",database="db1",metric="sessions_value",result="success"} 0.002214
+oracledb_exporter_last_metric_scrape_duration_seconds{collector="top_sql",database="db1",metric="top_sql_elapsed",result="success"} 0.041903
+```
+
+Each series is labelled with the metric's `context` (as `collector`), its unique identifier (as `metric`),
+the database label, and whether that scrape succeeded (as `result`). Only the most recent outcome is kept,
+so a metric contributes one series, not one per `result` value. A metric that has never been scraped --
+because its database is unreachable, or because it is not enabled for that database -- contributes nothing
+until it is scraped.
+
+### Cardinality
+
+This metric is opt-in because its series count scales with the number of databases you monitor:
+
+```
+series = (default metric definitions + custom metric definitions) x databases
+```
+
+The duration is reported per metric *definition*, not per resulting Prometheus metric. A definition that
+uses `fieldtoappend` produces several Prometheus metrics from a single query but is timed once: the
+`activity` metric above yields four metrics and one duration series.
+
+The default metrics file contains 12 metric definitions, so with the default metrics alone:
+
+| Databases | Custom metrics | Additional series |
+|-----------|----------------|-------------------|
+| 1         | 0              | 12                |
+| 100       | 0              | 1,200             |
+| 100       | 20             | 3,200             |
+| 300       | 20             | 9,600             |
+
+If you monitor many databases, consider enabling this metric temporarily while investigating slow scrapes,
+rather than leaving it on permanently.
 
 ## Build Info Metric
 

--- a/site/docs/releases/changelog.md
+++ b/site/docs/releases/changelog.md
@@ -9,7 +9,7 @@ List of upcoming and historic changes to the exporter.
 
 ### Next, TBD
 
-- Add the `oracledb_exporter_last_metric_scrape_duration_seconds` metric, reporting how long the last scrape of each individual metric took, per database, so slow queries can be identified without enabling debug logging.
+- Add the optional `oracledb_exporter_last_metric_scrape_duration_seconds` metric, reporting how long the last scrape of each individual metric took, per database, so slow queries can be identified without enabling debug logging. Disabled by default; enable it with `metrics.perMetricScrapeDuration.enabled`.
 
 ### 2.5.0, August 31st, 2026
 

--- a/site/docs/releases/changelog.md
+++ b/site/docs/releases/changelog.md
@@ -7,6 +7,10 @@ sidebar_position: 2
 
 List of upcoming and historic changes to the exporter.
 
+### Next, TBD
+
+- Add the `oracledb_exporter_last_metric_scrape_duration_seconds` metric, reporting how long the last scrape of each individual metric took, per database, so slow queries can be identified without enabling debug logging.
+
 ### 2.5.0, August 31st, 2026
 
 - Update the Go runtime to 1.26.6.


### PR DESCRIPTION
## 📌 Description

The exporter reported scrape duration for the whole scrape and per database, but not for individual metrics. Per-metric timing was already measured in scrapeDatabase and only written to the debug log, so identifying which query made a scrape slow required enabling debug logging and reading logs.

Export that timing as `oracledb_exporter_last_metric_scrape_duration_seconds`, a gauge labelled with the metric's context (as collector), its unique identifier (as metric), the configured database label, and whether the scrape succeeded (as result). Only one series exists per metric and database at a time: the series for the opposite result is removed, so the reported duration always describes the most recent scrape attempt.

Metrics served from the cache because of a custom scrape interval keep the value recorded by their last actual scrape. The gauge is reset when custom metrics are reloaded, so removed metric definitions stop reporting.

## ✅ Checklist

- [x] Code builds and runs locally
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [x] Follows project coding style and conventions
- [x] Signed the [Oracle Contributor Agreement (OCA)](https://oca.opensource.oracle.com/) to contribute to this project

